### PR TITLE
Remove incorrect note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ For more information on `mypy`, see https://www.mypy-lang.org/.
 Note:
 
 -   This extension is supported for all [actively supported versions](https://devguide.python.org/#status-of-python-branches) of the `python` language (i.e., python >= 3.7).
--   The bundled `mypy` is only used if there is no installed version of `mypy` found in the selected `python` environment.
 -   Minimum supported version of `mypy` is `1.0.0`.
 
 ## Usage


### PR DESCRIPTION
> -   The bundled `mypy` is only used if there is no installed version of `mypy` found in the selected `python` environment.

this isn't true, because as mentioned later in the readme, `mypy.importStrategy` defaults to `useBundled` (which imo is a bad default, why would you ever not want to use the environment's mypy?)