### PR TITLE
Add support for mypy `note`s

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -171,7 +171,11 @@ def _parse_output_using_regex(
                 if i + 1 < len(lines):
                     next_line = lines[i + 1]
                     next_data = _get_group_dict(next_line)
-                    if next_data and next_data["type"] == "note":
+                    if (
+                        next_data
+                        and next_data["type"] == "note"
+                        and next_data["location"] == data["location"]
+                    ):
                         continue
 
                 message = "\n".join(notes)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -127,7 +127,7 @@ DIAGNOSTIC_RE = re.compile(
 )
 
 
-def _get_group_dict(line: str) -> Optional[Dict[str, str]]:
+def _get_group_dict(line: str) -> Optional[Dict[str, str | None]]:
     match = DIAGNOSTIC_RE.match(line)
     if match:
         return match.groupdict()
@@ -182,10 +182,11 @@ def _parse_output_using_regex(
         start_line = int(data["line"])
         start_char = int(data["char"])
 
-        end_line = int(data["end_line"]) if data["end_line"] is not None else start_line
-        end_char = (
-            int(data["end_char"]) + 1 if data["end_char"] is not None else start_char
-        )
+        end_line = data["end_line"]
+        end_char = data["end_char"]
+
+        end_line = int(end_line) if end_line is not None else start_line
+        end_char = int(end_char) + 1 if end_char is not None else start_char
 
         start = lsp.Position(
             line=max(start_line - utils.LINE_OFFSET, 0),

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -19,6 +19,9 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 SERVER_CWD = os.getcwd()
 CWD_LOCK = threading.Lock()
 ERROR_CODE_BASE_URL = "https://mypy.readthedocs.io/en/latest/_refs.html#code-"
+SEE_HREF_PREFIX = "See https://mypy.readthedocs.io"
+SEE_PREFIX_LEN = len("See ")
+NOTE_CODE = "note"
 
 
 def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -22,6 +22,7 @@ ERROR_CODE_BASE_URL = "https://mypy.readthedocs.io/en/latest/_refs.html#code-"
 SEE_HREF_PREFIX = "See https://mypy.readthedocs.io"
 SEE_PREFIX_LEN = len("See ")
 NOTE_CODE = "note"
+LINE_OFFSET = CHAR_OFFSET = 1
 
 
 def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:

--- a/src/test/python_tests/test_data/sample1/sample.py
+++ b/src/test/python_tests/test_data/sample1/sample.py
@@ -2,6 +2,7 @@ import sys
 
 print(x)
 
+
 class Foo:
     def __eq__(self, other: "Foo") -> bool:
         return True

--- a/src/test/python_tests/test_data/sample1/sample.py
+++ b/src/test/python_tests/test_data/sample1/sample.py
@@ -1,3 +1,7 @@
 import sys
 
 print(x)
+
+class Foo:
+    def __eq__(self, other: "Foo") -> bool:
+        return True

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -59,7 +59,7 @@ def test_publish_diagnostics_on_open():
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 7},
+                    "end": {"line": 2, "character": 6},
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 1,
@@ -74,7 +74,7 @@ def test_publish_diagnostics_on_open():
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
@@ -90,7 +90,7 @@ def test_publish_diagnostics_on_open():
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": """This violates the Liskov substitution principle
@@ -154,7 +154,7 @@ def test_publish_diagnostics_on_save():
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 7},
+                    "end": {"line": 2, "character": 6},
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 1,
@@ -169,7 +169,7 @@ def test_publish_diagnostics_on_save():
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
@@ -185,7 +185,7 @@ def test_publish_diagnostics_on_save():
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": """This violates the Liskov substitution principle
@@ -314,7 +314,7 @@ def test_severity_setting(lint_code):
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 7},
+                    "end": {"line": 2, "character": 6},
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 2,
@@ -329,7 +329,7 @@ def test_severity_setting(lint_code):
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
@@ -345,7 +345,7 @@ def test_severity_setting(lint_code):
                     "start": {"line": 5, "character": 21},
                     "end": {
                         "line": 5,
-                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                        "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
                 "message": """This violates the Liskov substitution principle

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -74,9 +74,9 @@ def test_publish_diagnostics_on_open():
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
@@ -90,9 +90,9 @@ def test_publish_diagnostics_on_open():
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
@@ -172,9 +172,9 @@ def test_publish_diagnostics_on_save():
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
@@ -188,9 +188,9 @@ def test_publish_diagnostics_on_save():
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
@@ -335,9 +335,9 @@ def test_severity_setting(lint_code):
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },
@@ -351,9 +351,9 @@ def test_severity_setting(lint_code):
             },
             {
                 "range": {
-                    "start": {"line": 5, "character": 21},
+                    "start": {"line": 6, "character": 21},
                     "end": {
-                        "line": 5,
+                        "line": 6,
                         "character": 33 if sys.version_info >= (3, 8) else 21,
                     },
                 },

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -60,7 +60,7 @@ def test_publish_diagnostics_on_open():
                     "start": {"line": 2, "character": 6},
                     "end": {"line": 2, "character": 6},
                 },
-                "message": 'Name "x" is not defined  ',
+                "message": 'Name "x" is not defined',
                 "severity": 1,
                 "code": "name-defined",
                 "codeDescription": {
@@ -117,7 +117,7 @@ def test_publish_diagnostics_on_save():
                     "start": {"line": 2, "character": 6},
                     "end": {"line": 2, "character": 6},
                 },
-                "message": 'Name "x" is not defined  ',
+                "message": 'Name "x" is not defined',
                 "severity": 1,
                 "code": "name-defined",
                 "codeDescription": {
@@ -239,7 +239,7 @@ def test_severity_setting(lint_code):
                     "start": {"line": 2, "character": 6},
                     "end": {"line": 2, "character": 6},
                 },
-                "message": 'Name "x" is not defined  ',
+                "message": 'Name "x" is not defined',
                 "severity": 2,
                 "code": "name-defined",
                 "codeDescription": {

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -4,6 +4,7 @@
 Test for linting over LSP.
 """
 
+import sys
 from threading import Event
 
 import pytest
@@ -71,7 +72,10 @@ def test_publish_diagnostics_on_open():
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
                 "severity": 1,
@@ -84,7 +88,10 @@ def test_publish_diagnostics_on_open():
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": """This violates the Liskov substitution principle
 See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
@@ -160,7 +167,10 @@ def test_publish_diagnostics_on_save():
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
                 "severity": 1,
@@ -173,7 +183,10 @@ def test_publish_diagnostics_on_save():
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": """This violates the Liskov substitution principle
 See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
@@ -314,7 +327,10 @@ def test_severity_setting(lint_code):
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
                 "severity": 1,
@@ -327,7 +343,10 @@ def test_severity_setting(lint_code):
             {
                 "range": {
                     "start": {"line": 5, "character": 21},
-                    "end": {"line": 5, "character": 32},
+                    "end": {
+                        "line": 5,
+                        "character": 32 if sys.version_info >= (3, 8) else 21,
+                    },
                 },
                 "message": """This violates the Liskov substitution principle
 See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -67,7 +67,39 @@ def test_publish_diagnostics_on_open():
                     "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-name-defined"
                 },
                 "source": "Mypy",
-            }
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
+                "severity": 1,
+                "code": "override",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-override"
+                },
+                "source": "Mypy",
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": """This violates the Liskov substitution principle
+See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+It is recommended for "__eq__" to work with arbitrary objects, for example:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            return NotImplemented
+        return <logic to compare two Foo instances>""",
+                "severity": 3,
+                "code": "note",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides"
+                },
+                "source": "Mypy",
+            },
         ],
     }
 
@@ -124,7 +156,39 @@ def test_publish_diagnostics_on_save():
                     "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-name-defined"
                 },
                 "source": "Mypy",
-            }
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
+                "severity": 1,
+                "code": "override",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-override"
+                },
+                "source": "Mypy",
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": """This violates the Liskov substitution principle
+See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+It is recommended for "__eq__" to work with arbitrary objects, for example:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            return NotImplemented
+        return <logic to compare two Foo instances>""",
+                "severity": 3,
+                "code": "note",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides"
+                },
+                "source": "Mypy",
+            },
         ],
     }
 
@@ -246,7 +310,39 @@ def test_severity_setting(lint_code):
                     "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-name-defined"
                 },
                 "source": "Mypy",
-            }
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
+                "severity": 1,
+                "code": "override",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-override"
+                },
+                "source": "Mypy",
+            },
+            {
+                "range": {
+                    "start": {"line": 5, "character": 21},
+                    "end": {"line": 5, "character": 32},
+                },
+                "message": """This violates the Liskov substitution principle
+See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+It is recommended for "__eq__" to work with arbitrary objects, for example:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            return NotImplemented
+        return <logic to compare two Foo instances>""",
+                "severity": 3,
+                "code": "note",
+                "codeDescription": {
+                    "href": "https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides"
+                },
+                "source": "Mypy",
+            },
         ],
     }
 

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -59,7 +59,10 @@ def test_publish_diagnostics_on_open():
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 6},
+                    "end": {
+                        "line": 2,
+                        "character": 7 if sys.version_info >= (3, 8) else 6,
+                    },
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 1,
@@ -154,7 +157,10 @@ def test_publish_diagnostics_on_save():
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 6},
+                    "end": {
+                        "line": 2,
+                        "character": 7 if sys.version_info >= (3, 8) else 6,
+                    },
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 1,
@@ -314,7 +320,10 @@ def test_severity_setting(lint_code):
             {
                 "range": {
                     "start": {"line": 2, "character": 6},
-                    "end": {"line": 2, "character": 6},
+                    "end": {
+                        "line": 2,
+                        "character": 7 if sys.version_info >= (3, 8) else 6,
+                    },
                 },
                 "message": 'Name "x" is not defined',
                 "severity": 2,


### PR DESCRIPTION
support mypy notes.

this was previously broken due to the regex not supporting `note`s, as it required the `[code]` at the end (which notes do not have).

i also added a method of accumulating notes so that they don't span over multiple diagnostics, and instead are attached as one `note` diagnostic.

it also automatically finds `See <url>` lines in `note` diagnostics and attaches them in the code description.

also fixed the regex to exclude the two spaces before a `[code]`, and merged both the regexes into one.

<img width="874" alt="image" src="https://github.com/microsoft/vscode-mypy/assets/41439633/af26886f-254b-4b75-85f1-e09e13edcf03">


