### PR TITLE
Fix spurious errors when using `--follow-imports=normal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
             "properties": {
                 "mypy-type-checker.args": {
                     "default": [
-                        "--follow-imports=skip"
+                        "--follow-imports=normal"
                     ],
                     "markdownDescription": "%settings.args.description%",
                     "items": {


### PR DESCRIPTION
Fixes #62 

When generating diagnostics for a file while using `--follow-imports=normal`, mypy will emit errors that occur in both the requested file and any other files it may import. However, the extension doesn't check which file an error originates from, leading to errors from other files being incorrectly reported as being for the requested file. These changes fix that behavior by stripping out all errors originating from files other than the requested file.

Additionally, this changes the default `mypy` configuration to be `--follow-imports=normal`. This makes it more similar to the previous behavior before #52, where `--follow-imports=silent` (which is not supported by `dmypy`) was used to suppress error messages while still allowing mypy to pull in useful type information from imported files.