### PR TITLE
Remove follow-imports argument which may conflict with projects

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -157,7 +157,8 @@ def _parse_output_using_regex(
             continue
 
         # skip output from other documents
-        # (causes --follow-imports=normal to behave like silent).
+        # (mypy will follow imports, so may include errors found in other
+        # documents; this is fine/correct, we just need to account for it).
         if data["filepath"] != document.path:
             continue
 

--- a/package.json
+++ b/package.json
@@ -66,9 +66,7 @@
         "configuration": {
             "properties": {
                 "mypy-type-checker.args": {
-                    "default": [
-                        "--follow-imports=normal"
-                    ],
+                    "default": [],
                     "markdownDescription": "%settings.args.description%",
                     "items": {
                         "type": "string"


### PR DESCRIPTION
mypy prioritises values from configuration on its command line over that provided in configuration files. This means that the value previously provided here could override the settings for a project, cause spurious errors and/or hiding true errors.

Removing this default value allows users freedom to configure their projects however they like, without the extension injecting unexpected additional configuration within the IDE context.

Tested manually by opening a project which has a `setup.cfg` and changing the `follow_imports` value within that file, then checking the errors reported from `mypy` change accordingly.

Fixes https://github.com/microsoft/vscode-mypy/issues/89