### PR TITLE
Fix typo in default `mypy` args

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -65,7 +65,7 @@ TOOL_ARGS = [
     "--no-error-summary",
     "--show-absolute-path",
     "--show-column-numbers",
-    "--show-error-code",
+    "--show-error-codes",
     "--no-pretty",
 ]
 MIN_VERSION = "1.0.0"


### PR DESCRIPTION
This typo causes problem only in the latest version of mypy where this results in an ambiguous CLI argument error.