### PR TITLE
Clear diagnostic results on documents

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -121,9 +121,7 @@ def _linting_helper(document: workspace.Document) -> None:
             reportingScope = settings["reportingScope"]
             diagnostics_contain_document_entry = False
             for file_path, diagnostics in parse_results.items():
-                is_file_same_as_document = utils.is_same_path(
-                    file_path, document.path
-                )
+                is_file_same_as_document = utils.is_same_path(file_path, document.path)
                 if is_file_same_as_document:
                     diagnostics_contain_document_entry = True
                 # skip output from other documents

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -119,17 +119,25 @@ def _linting_helper(document: workspace.Document) -> None:
                 result.stdout, settings["severity"]
             )
             reportingScope = settings["reportingScope"]
+            diagnostics_contain_document_entry = false
             for file_path, diagnostics in parse_results.items():
+                is_file_same_as_document = utils.is_same_path(
+                    file_path, document.path
+                )
+                if is_file_same_as_document:
+                    diagnostics_contain_document_entry = true
                 # skip output from other documents
                 # (mypy will follow imports, so may include errors found in other
                 # documents; this is fine/correct, we just need to account for it).
-                if reportingScope == "file" and utils.is_same_path(
-                    file_path, document.path
-                ):
+                if reportingScope == "file" and is_file_same_as_document:
                     LSP_SERVER.publish_diagnostics(document.uri, diagnostics)
                 elif reportingScope == "workspace":
                     uri = uris.from_fs_path(utils.normalize_path(file_path))
                     LSP_SERVER.publish_diagnostics(uri, diagnostics)
+            if not diagnostics_contain_document_entry:
+                # Ensure that if nothing is returned for this document, at least
+                # an empty diagnostic is returned to clear any old errors out.
+                LSP_SERVER.publish_diagnostics(document.uri, [])
     except Exception:
         LSP_SERVER.show_message_log(
             f"Linting failed with error:\r\n{traceback.format_exc()}",

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -119,13 +119,13 @@ def _linting_helper(document: workspace.Document) -> None:
                 result.stdout, settings["severity"]
             )
             reportingScope = settings["reportingScope"]
-            diagnostics_contain_document_entry = false
+            diagnostics_contain_document_entry = False
             for file_path, diagnostics in parse_results.items():
                 is_file_same_as_document = utils.is_same_path(
                     file_path, document.path
                 )
                 if is_file_same_as_document:
-                    diagnostics_contain_document_entry = true
+                    diagnostics_contain_document_entry = True
                 # skip output from other documents
                 # (mypy will follow imports, so may include errors found in other
                 # documents; this is fine/correct, we just need to account for it).

--- a/src/test/python_tests/test_data/sample1/sample3.py
+++ b/src/test/python_tests/test_data/sample1/sample3.py
@@ -1,0 +1,4 @@
+"""A Sample file with no errors."""
+x: str = "Hello"
+
+print(x)

--- a/src/test/python_tests/test_data/sample1/sample3.py
+++ b/src/test/python_tests/test_data/sample1/sample3.py
@@ -1,4 +1,6 @@
 """A Sample file with no errors."""
+
+
 x: str = "Hello"
 
 print(x)

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -503,3 +503,179 @@ It is recommended for "__eq__" to work with arbitrary objects, for example:
             },
         ]
         assert_that(actual, is_(expected))
+
+
+def test_file_with_no_errors_generates_empty_diagnostics():
+    """Test that a file with no errors generates an empty diagnostics array. This ensures that errors are cleared out."""
+    TEST_FILE3_PATH = constants.TEST_DATA / "sample1" / "sample3.py"
+    TEST_FILE3_URI = utils.as_uri(str(TEST_FILE3_PATH))
+    contents = TEST_FILE3_PATH.read_text(encoding="utf-8")
+
+    actual = []
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+
+        done = Event()
+
+        def _handler(params):
+            nonlocal actual
+            actual = params
+            done.set()
+
+        def _log_handler(params):
+            print(params)
+
+        ls_session.set_notification_callback(session.WINDOW_LOG_MESSAGE, _log_handler)
+        ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
+
+        ls_session.notify_did_open(
+            {
+                "textDocument": {
+                    "uri": TEST_FILE3_URI,
+                    "languageId": "python",
+                    "version": 1,
+                    "text": contents,
+                }
+            }
+        )
+
+        # wait for some time to receive all notifications
+        assert done.wait(TIMEOUT), "Timed out waiting for diagnostics"
+
+        expected = {
+            "uri": TEST_FILE3_URI,
+            "diagnostics": [],
+        }
+        assert_that(actual, is_(expected))
+
+
+def test_file_with_no_errors_generates_empty_diagnostics_workspace_mode():
+    """Test that a file with no errors generates an empty diagnostics array. This ensures that errors are cleared out."""
+    TEST_FILE2_PATH = constants.TEST_DATA / "sample1" / "sample2.py"
+    TEST_FILE2_URI = utils.as_uri(str(TEST_FILE2_PATH))
+    TEST_FILE3_PATH = constants.TEST_DATA / "sample1" / "sample3.py"
+    TEST_FILE3_URI = utils.as_uri(str(TEST_FILE3_PATH))
+    contents = TEST_FILE3_PATH.read_text(encoding="utf-8")
+
+    actual = []
+    with session.LspSession() as ls_session:
+        init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
+        init_options = init_args["initializationOptions"]
+        init_options["settings"][0]["reportingScope"] = "workspace"
+        ls_session.initialize(init_args)
+
+        done = Event()
+
+        def _handler(params):
+            params["uri"] = utils.normalizecase(params["uri"])
+            actual.append(params)
+            if len(actual) == 2:
+                done.set()
+
+        def _log_handler(params):
+            print(params)
+
+        ls_session.set_notification_callback(session.WINDOW_LOG_MESSAGE, _log_handler)
+        ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
+
+        ls_session.notify_did_open(
+            {
+                "textDocument": {
+                    "uri": TEST_FILE3_URI,
+                    "languageId": "python",
+                    "version": 1,
+                    "text": contents,
+                }
+            }
+        )
+
+        # wait for some time to receive all notifications
+        assert done.wait(TIMEOUT), "Timed out waiting for diagnostics"
+
+        expected = expected = [
+            {
+                "uri": TEST_FILE_URI,
+                "diagnostics": [
+                    {
+                        "range": {
+                            "start": {"line": 2, "character": 6},
+                            "end": {
+                                "line": 2,
+                                "character": 7 if sys.version_info >= (3, 8) else 6,
+                            },
+                        },
+                        "message": 'Name "x" is not defined',
+                        "severity": 1,
+                        "code": "name-defined",
+                        "codeDescription": {
+                            "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-name-defined"
+                        },
+                        "source": "Mypy",
+                    },
+                    {
+                        "range": {
+                            "start": {"line": 6, "character": 21},
+                            "end": {
+                                "line": 6,
+                                "character": 33 if sys.version_info >= (3, 8) else 21,
+                            },
+                        },
+                        "message": 'Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"',
+                        "severity": 1,
+                        "code": "override",
+                        "codeDescription": {
+                            "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-override"
+                        },
+                        "source": "Mypy",
+                    },
+                    {
+                        "range": {
+                            "start": {"line": 6, "character": 21},
+                            "end": {
+                                "line": 6,
+                                "character": 33 if sys.version_info >= (3, 8) else 21,
+                            },
+                        },
+                        "message": """This violates the Liskov substitution principle
+See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+It is recommended for "__eq__" to work with arbitrary objects, for example:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            return NotImplemented
+        return <logic to compare two Foo instances>""",
+                        "severity": 3,
+                        "code": "note",
+                        "codeDescription": {
+                            "href": "https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides"
+                        },
+                        "source": "Mypy",
+                    },
+                ],
+            },
+            {
+                "uri": TEST_FILE2_URI,
+                "diagnostics": [
+                    {
+                        "range": {
+                            "start": {"line": 2, "character": 9},
+                            "end": {
+                                "line": 2,
+                                "character": 16 if sys.version_info >= (3, 8) else 9,
+                            },
+                        },
+                        "message": 'Incompatible types in assignment (expression has type "str", variable has type "int")',
+                        "severity": 1,
+                        "code": "assignment",
+                        "codeDescription": {
+                            "href": "https://mypy.readthedocs.io/en/latest/_refs.html#code-assignment"
+                        },
+                        "source": "Mypy",
+                    }
+                ],
+            },
+            {
+                "uri": TEST_FILE3_URI,
+                "diagnostics": [],
+            },
+        ]
+        assert_that(actual, is_(expected))


### PR DESCRIPTION
When a document is scanned and no errors are returned, no diagnostic is reported to the LSP_SERVER. This change checks for diagnostics against the specific file. If none are created, it clears the errors on that file by reporting an empty set of diagnostics.

Tested with unit tests, but not installed and tested yet...

Fixes: https://github.com/microsoft/vscode-mypy/issues/119