### PR TITLE
Import bundled `packaging` after path munging

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -15,9 +15,6 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
-from packaging.version import Version
-from packaging.version import parse as parse_version
-
 
 # **********************************************************
 # Update sys.path before importing any bundled libraries.
@@ -46,6 +43,8 @@ update_sys_path(
 # **********************************************************
 import lsp_utils as utils
 import lsprotocol.types as lsp
+from packaging.version import Version
+from packaging.version import parse as parse_version
 from pygls import server, uris, workspace
 
 WORKSPACE_SETTINGS = {}


### PR DESCRIPTION
When using the bundled strategy and a vanilla system-wide interpreter (e.g., `/usr/bin/python3`) with `v2023.3.12551007`, `lsp_server.py` would die when attempting to import `packaging`. This is because the import was attempted before any `useBundled`-related path munging was made. This commit corrects for that.

Fixes #148.

---
FYI, I don't have a great testing strategy for this, but when I performed these edits by hand in my own `~/.vscode-server/extensions/ms-python.mypy-type-checker-2023.3.12551007/bundled/tool/lsp_server.py` (remote workflow) and `~/.vscode/extensions/ms-python.mypy-type-checker-2023.3.12551007/bundled/tool/lsp_server.py` (local workflow) files, I was able to use system-wide vanilla Pythons with the `useBundled` strategy without apparent issues after reloading my respective workspaces.