### PR TITLE
fix: usage of `setup-node@v3` in `push-check`

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -111,7 +111,7 @@ jobs:
           path: ${{ env.special-working-directory-relative }}
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
fixes #317.