### PR TITLE
fix: usage of `node12 which is deprecated` in CI

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -121,7 +121,7 @@ jobs:
         shell: bash
 
       - name: Run TS tests
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: GabrielBB/xvfb-action@v1.7
         with:
           run: npm run tests
           working-directory: ${{ env.special-working-directory }}

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -126,7 +126,7 @@ jobs:
         shell: bash
 
       - name: Run TS tests
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: GabrielBB/xvfb-action@v1.7
         with:
           run: npm run tests
           working-directory: ${{ env.special-working-directory }}


### PR DESCRIPTION
Fixes #335