### PR TITLE
Add dmypy status file setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ There are several settings you can configure to customize the behavior of this e
       <td>(experimental) Whether the Mypy daemon (<code>dmypy</code>) will take precedence over <code>mypy</code> for type checking. Note: if <code>mypy-type-checker.reportingScope</code> is set to <code>workspace</code>, enabling the Mypy daemon will offer a faster type checking experience. This setting will be overridden if <code>mypy-type-checker.path</code> is set.
     </tr>
     <tr>
+      <td>mypy-type-checker.daemonStatusFile</td>
+      <td><code>""</code></td>
+      <td>(experimental) Path to the status file used by the Mypy daemon (<code>dmypy</code>).
+    </tr>
+    <tr>
       <td>mypy-type-checker.ignorePatterns</td>
       <td><code>[]</code></td>
       <td>Configure <a href="https://docs.python.org/3/library/fnmatch.html">glob patterns</a> as supported by the fnmatch Python library to exclude files or folders from being type checked by Mypy.</td>

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -501,6 +501,7 @@ def _get_global_defaults():
         "extraPaths": GLOBAL_SETTINGS.get("extraPaths", []),
         "reportingScope": GLOBAL_SETTINGS.get("reportingScope", "file"),
         "preferDaemon": GLOBAL_SETTINGS.get("preferDaemon", True),
+        "daemonStatusFile": GLOBAL_SETTINGS.get("daemonStatusFile", ""),
     }
 
 
@@ -611,9 +612,12 @@ def _get_dmypy_args(settings: Dict[str, Any], command: str) -> List[str]:
         raise ValueError(f"Invalid dmypy command: {command}")
 
     if key not in DMYPY_ARGS:
-        STATUS_FILE_NAME = os.fspath(
-            DMYPY_STATUS_FILE_ROOT / f"status-{str(uuid.uuid4())}.json"
-        )
+        if settings["daemonStatusFile"]:
+            STATUS_FILE_NAME = settings["daemonStatusFile"]
+        else:
+            STATUS_FILE_NAME = os.fspath(
+                DMYPY_STATUS_FILE_ROOT / f"status-{str(uuid.uuid4())}.json"
+            )
         args = ["--status-file", STATUS_FILE_NAME]
         DMYPY_ARGS[key] = args
 

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
                     "default": "",
                     "markdownDescription": "%settings.daemonStatusFile.description%",
                     "scope": "resource",
-                    "type": "string"
+                    "type": "string",
+                    "tags": ["experimental"]
                 },
                 "mypy-type-checker.reportingScope": {
                     "default": "file",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
                     "scope": "resource",
                     "type": "boolean"
                 },
+                "mypy-type-checker.daemonStatusFile": {
+                    "default": "",
+                    "markdownDescription": "%settings.daemonStatusFile.description%",
+                    "scope": "resource",
+                    "type": "string"
+                },
                 "mypy-type-checker.reportingScope": {
                     "default": "file",
                     "markdownDescription": "%settings.reportingScope.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,7 @@
     "settings.importStrategy.fromEnvironment.description": "Use Mypy from the selected environment. If the extension fails to find a valid Mypy binary, it will fallback to using the bundled version of Mypy.",
     "settings.interpreter.description": "Path to a Python executable or a command that will be used to launch the Mypy server and any subprocess. Accepts an array of a single or multiple strings. When set to `[]`, the extension will use the path to the selected Python interpreter. If passing a command, each argument should be provided as a separate string in the array.",
     "settings.preferDaemon.description": "Whether the Mypy daemon (`dmypy`) will take precedence over `mypy`for type checking. <br> Note: if `mypy-type-checker.reportingScope`is set to `workspace`, enabling the Mypy daemon will offer a faster type checking experience. This setting will be overridden if `mypy-type-checker.path`is set.",
+    "settings.daemonStatusFile.description": "Path to the status file used by the Mypy daemon (`dmypy`).",
     "settings.reportingScope.description": "Controls the scope of Mypy's problem reporting. If set to `file`, Mypy will limit its problem reporting to the files currently open in the editor. If set to `workspace`, Mypy will extend its problem reporting to include all files within the workspace.             ",
     "settings.reportingScope.file.description": "Problems are reported for the files open in the editor only.",
     "settings.reportingScope.workspace.description": "Problems are reported for all files within the workspace.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -25,6 +25,7 @@ export interface ISettings {
     extraPaths: string[];
     reportingScope: string;
     preferDaemon: boolean;
+    daemonStatusFile: string;
 }
 
 export function getExtensionSettings(namespace: string, includeInterpreter?: boolean): Promise<ISettings[]> {
@@ -120,6 +121,7 @@ export async function getWorkspaceSettings(
         extraPaths: resolveVariables(extraPaths, workspace),
         reportingScope: config.get<string>('reportingScope', 'file'),
         preferDaemon: config.get<boolean>('preferDaemon', true),
+        daemonStatusFile: config.get<string>('daemonStatusFile', ''),
     };
     return workspaceSetting;
 }
@@ -153,6 +155,7 @@ export async function getGlobalSettings(namespace: string, includeInterpreter?: 
         extraPaths: getGlobalValue<string[]>(config, 'extraPaths', []),
         reportingScope: config.get<string>('reportingScope', 'file'),
         preferDaemon: config.get<boolean>('preferDaemon', true),
+        daemonStatusFile: config.get<string>('daemonStatusFile', ''),
     };
     return setting;
 }
@@ -169,6 +172,7 @@ export function checkIfConfigurationChanged(e: ConfigurationChangeEvent, namespa
         `${namespace}.reportingScope`,
         `${namespace}.preferDaemon`,
         `${namespace}.ignorePatterns`,
+        `${namespace}.daemonStatusFile`,
         'python.analysis.extraPaths',
     ];
     const changed = settings.map((s) => e.affectsConfiguration(s));


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-mypy/issues/332

As suggested in the issue, adding `daemonStatusFile` setting, which allow setting custom status file, so that dmypy can be reused outside the extension.