### PR TITLE
Sync with template: Fix duplicate server handlers on concurrent restarts

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -98,9 +98,9 @@ export async function restartServer(
         } catch (ex) {
             traceError(`Server: Stop failed: ${ex}`);
         }
-        _disposables.forEach((d) => d.dispose());
-        _disposables = [];
     }
+    _disposables.forEach((d) => d.dispose());
+    _disposables = [];
     updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
     const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export async function deactivate(): Promise<void> {
     if (lsClient) {
-        await lsClient.stop();
+        try {
+            await lsClient.stop();
+        } catch (ex) {
+            traceError(`Server: Stop failed: ${ex}`);
+        }
     }
 }


### PR DESCRIPTION
- Move _disposables cleanup outside the if(oldLsClient) block in restartServer() so disposables are always cleaned up even if the old client is undefined
- Add try/catch around lsClient.stop() in deactivate() to prevent unhandled exceptions during extension deactivation

Source: microsoft/vscode-python-tools-extension-template#259