### PR TITLE
Refactor: add notebook support to getDocumentSelector

### DIFF
--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -74,6 +74,8 @@ export function getDocumentSelector(): DocumentSelector {
         : [
               { scheme: 'file', language: 'python' },
               { scheme: 'untitled', language: 'python' },
+              { scheme: 'vscode-notebook', language: 'python' },
+              { scheme: 'vscode-notebook-cell', language: 'python' },
           ];
 }
 

--- a/src/test/ts_tests/tests/common/utilities.unit.test.ts
+++ b/src/test/ts_tests/tests/common/utilities.unit.test.ts
@@ -21,6 +21,8 @@ suite('Document Selector Tests', () => {
         assert.deepStrictEqual(selector, [
             { scheme: 'file', language: 'python' },
             { scheme: 'untitled', language: 'python' },
+            { scheme: 'vscode-notebook', language: 'python' },
+            { scheme: 'vscode-notebook-cell', language: 'python' },
         ]);
     });
     test('Document selector virtual workspace', () => {


### PR DESCRIPTION
## Summary

Add \scode-notebook\ and \scode-notebook-cell\ schemes to \getDocumentSelector()\ in \src/common/utilities.ts\, matching the black/flake8/isort/pylint implementations. This enables mypy to work with Python notebooks, aligning with the other linting/formatting extensions.

## Changes

- Added \{ scheme: 'vscode-notebook', language: 'python' }\ to the document selector
- Added \{ scheme: 'vscode-notebook-cell', language: 'python' }\ to the document selector

## References

- Part of #504
- Ref: microsoft/vscode-python-tools-extension-template#290