### PR TITLE
Refactor: backport shared test coverage (envFile + configWatcher dispose)

### DIFF
--- a/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
+++ b/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
@@ -3,80 +3,48 @@
 
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import { Disposable, FileSystemWatcher, workspace } from 'vscode';
+import { workspace } from 'vscode';
 import { createConfigFileWatchers } from '../../../../common/configWatcher';
 import { MYPY_CONFIG_FILES } from '../../../../common/constants';
 
-interface MockFileSystemWatcher {
-    watcher: FileSystemWatcher;
-    fireDidCreate(): Promise<void>;
-    fireDidChange(): Promise<void>;
-    fireDidDelete(): Promise<void>;
-}
-
-function createMockFileSystemWatcher(): MockFileSystemWatcher {
-    let onDidChangeHandler: (() => Promise<void>) | undefined;
-    let onDidCreateHandler: (() => Promise<void>) | undefined;
-    let onDidDeleteHandler: (() => Promise<void>) | undefined;
-
-    const watcher = {
-        onDidChange: (handler: () => Promise<void>): Disposable => {
-            onDidChangeHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidCreate: (handler: () => Promise<void>): Disposable => {
-            onDidCreateHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidDelete: (handler: () => Promise<void>): Disposable => {
-            onDidDeleteHandler = handler;
-            return { dispose: () => {} };
-        },
-        dispose: () => {},
-    } as unknown as FileSystemWatcher;
-
-    return {
-        watcher,
-        fireDidCreate: async () => {
-            if (onDidCreateHandler) {
-                await onDidCreateHandler();
-            }
-        },
-        fireDidChange: async () => {
-            if (onDidChangeHandler) {
-                await onDidChangeHandler();
-            }
-        },
-        fireDidDelete: async () => {
-            if (onDidDeleteHandler) {
-                await onDidDeleteHandler();
-            }
-        },
-    };
-}
-
 suite('Config File Watcher Tests', () => {
-    let sandbox: sinon.SinonSandbox;
     let createFileSystemWatcherStub: sinon.SinonStub;
-    let mockWatchers: MockFileSystemWatcher[];
+    let mockWatcher: {
+        onDidChange: sinon.SinonStub;
+        onDidCreate: sinon.SinonStub;
+        onDidDelete: sinon.SinonStub;
+        dispose: sinon.SinonStub;
+    };
+    let changeDisposable: { dispose: sinon.SinonStub };
+    let createDisposable: { dispose: sinon.SinonStub };
+    let deleteDisposable: { dispose: sinon.SinonStub };
+    let onConfigChangedCallback: sinon.SinonStub;
 
     setup(() => {
-        sandbox = sinon.createSandbox();
-        mockWatchers = MYPY_CONFIG_FILES.map(() => createMockFileSystemWatcher());
+        changeDisposable = { dispose: sinon.stub() };
+        createDisposable = { dispose: sinon.stub() };
+        deleteDisposable = { dispose: sinon.stub() };
 
-        let watcherIndex = 0;
-        createFileSystemWatcherStub = sandbox.stub(workspace, 'createFileSystemWatcher').callsFake(() => {
-            return mockWatchers[watcherIndex++].watcher;
-        });
+        mockWatcher = {
+            onDidChange: sinon.stub().returns(changeDisposable),
+            onDidCreate: sinon.stub().returns(createDisposable),
+            onDidDelete: sinon.stub().returns(deleteDisposable),
+            dispose: sinon.stub(),
+        };
+
+        createFileSystemWatcherStub = sinon.stub(workspace, 'createFileSystemWatcher');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createFileSystemWatcherStub.returns(mockWatcher as any);
+
+        onConfigChangedCallback = sinon.stub().resolves();
     });
 
     teardown(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     test('Creates a file watcher for each mypy config file pattern', () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        createConfigFileWatchers(onConfigChanged);
+        createConfigFileWatchers(onConfigChangedCallback);
 
         assert.strictEqual(createFileSystemWatcherStub.callCount, MYPY_CONFIG_FILES.length);
         for (let i = 0; i < MYPY_CONFIG_FILES.length; i++) {
@@ -88,55 +56,87 @@ suite('Config File Watcher Tests', () => {
     });
 
     test('Server restarts when a config file is created', async () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        createConfigFileWatchers(onConfigChanged);
+        createConfigFileWatchers(onConfigChangedCallback);
 
-        await mockWatchers[0].fireDidCreate();
+        const createHandler = mockWatcher.onDidCreate.getCall(0).args[0];
+        await createHandler();
 
-        assert.isTrue(onConfigChanged.calledOnce, 'Expected onConfigChanged to be called when config file is created');
+        assert.isTrue(
+            onConfigChangedCallback.calledOnce,
+            'Expected onConfigChanged to be called when config file is created',
+        );
     });
 
     test('Server restarts when a config file is changed', async () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        createConfigFileWatchers(onConfigChanged);
+        createConfigFileWatchers(onConfigChangedCallback);
 
         // Simulate modifying pyproject.toml (index 2)
-        await mockWatchers[2].fireDidChange();
+        const changeHandler = mockWatcher.onDidChange.getCall(2).args[0];
+        await changeHandler();
 
-        assert.isTrue(onConfigChanged.calledOnce, 'Expected onConfigChanged to be called when config file is changed');
+        assert.isTrue(
+            onConfigChangedCallback.calledOnce,
+            'Expected onConfigChanged to be called when config file is changed',
+        );
     });
 
     test('Server restarts when a config file is deleted', async () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        createConfigFileWatchers(onConfigChanged);
+        createConfigFileWatchers(onConfigChangedCallback);
 
-        await mockWatchers[3].fireDidDelete();
+        const deleteHandler = mockWatcher.onDidDelete.getCall(3).args[0];
+        await deleteHandler();
 
-        assert.isTrue(onConfigChanged.calledOnce, 'Expected onConfigChanged to be called when config file is deleted');
+        assert.isTrue(
+            onConfigChangedCallback.calledOnce,
+            'Expected onConfigChanged to be called when config file is deleted',
+        );
     });
 
     test('Server restarts for each config file type on change', async () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        createConfigFileWatchers(onConfigChanged);
+        createConfigFileWatchers(onConfigChangedCallback);
 
-        for (const mock of mockWatchers) {
-            await mock.fireDidChange();
+        for (let i = 0; i < MYPY_CONFIG_FILES.length; i++) {
+            const changeHandler = mockWatcher.onDidChange.getCall(i).args[0];
+            await changeHandler();
         }
 
         assert.strictEqual(
-            onConfigChanged.callCount,
+            onConfigChangedCallback.callCount,
             MYPY_CONFIG_FILES.length,
             `Expected onConfigChanged to be called once for each of the ${MYPY_CONFIG_FILES.length} config file patterns`,
         );
     });
 
     test('Returns a disposable for each watcher', () => {
-        const onConfigChanged = sandbox.stub().resolves();
-        const disposables = createConfigFileWatchers(onConfigChanged);
+        const disposables = createConfigFileWatchers(onConfigChangedCallback);
 
         assert.strictEqual(disposables.length, MYPY_CONFIG_FILES.length);
         for (const d of disposables) {
             assert.isFunction(d.dispose);
         }
+    });
+
+    test('Should dispose all subscriptions and watcher on dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        watchers[0].dispose();
+
+        assert.strictEqual(changeDisposable.dispose.callCount, 1, 'Change subscription should be disposed');
+        assert.strictEqual(createDisposable.dispose.callCount, 1, 'Create subscription should be disposed');
+        assert.strictEqual(deleteDisposable.dispose.callCount, 1, 'Delete subscription should be disposed');
+        assert.strictEqual(mockWatcher.dispose.callCount, 1, 'Watcher should be disposed');
+    });
+
+    test('Should not call callback after dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        // Dispose the watcher
+        watchers[0].dispose();
+
+        // Get the handlers and call them after disposal
+        const changeHandler = mockWatcher.onDidChange.getCall(0).args[0];
+        changeHandler();
+
+        assert.strictEqual(onConfigChangedCallback.callCount, 0, 'Callback should not be called after dispose');
     });
 });

--- a/src/test/ts_tests/tests/common/envFile.unit.test.ts
+++ b/src/test/ts_tests/tests/common/envFile.unit.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { Uri, WorkspaceFolder } from 'vscode';
+import { getEnvFileVars } from '../../../../common/envFile';
+import * as vscodeapi from '../../../../common/vscodeapi';
+
+// Use real files instead of stubbing fs-extra (whose exports are non-configurable).
+suite('getEnvFileVars Tests', () => {
+    let getConfigurationStub: sinon.SinonStub;
+
+    const fixtureDir = path.join(__dirname, '.envfile-test-fixtures');
+
+    const workspaceFolder: WorkspaceFolder = {
+        uri: Uri.file(fixtureDir),
+        name: 'workspace',
+        index: 0,
+    };
+
+    setup(async () => {
+        await fs.ensureDir(fixtureDir);
+        getConfigurationStub = sinon.stub(vscodeapi, 'getConfiguration');
+    });
+
+    teardown(async () => {
+        sinon.restore();
+        await fs.remove(fixtureDir);
+    });
+
+    test('returns parsed variables from existing .env file', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env'), 'FOO=bar\nBAZ=qux\n');
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { FOO: 'bar', BAZ: 'qux' });
+    });
+
+    test('returns empty object for missing file', async () => {
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        assert.deepStrictEqual(vars, {});
+    });
+
+    test('resolves ${workspaceFolder} in path', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.test'), 'KEY=value\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '${workspaceFolder}/.env.test',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { KEY: 'value' });
+    });
+
+    test('resolves relative paths', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.local'), 'RELATIVE=yes\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '.env.local',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { RELATIVE: 'yes' });
+    });
+});


### PR DESCRIPTION
Backports shared test coverage from sibling extension repos to ensure consistent test coverage before shared package extraction.

### Changes
- **envFile.unit.test.ts** (4 tests): Tests for \getEnvFileVars\ — env file parsing, missing file handling, variable resolution. Copied from isort.
- **configWatcher dispose** (2 tests): Tests that disposal properly cleans up subscriptions and prevents post-dispose callbacks. Backported from pylint.

Part of microsoft/vscode-python-tools-extension-template#290