### PR TITLE
test: backport shared test coverage (logging, stdlib_detection)

### DIFF
--- a/src/test/python_tests/test_logging.py
+++ b/src/test/python_tests/test_logging.py
@@ -1,0 +1,160 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Unit tests for the logging/notification helpers in lsp_server.
+
+Covers the Pygls 2 migration which changed logging calls from
+show_message_log/show_message to window_log_message/window_show_message
+with parameter objects, and verifies the LS_SHOW_NOTIFICATION gating logic.
+
+Mock setup is provided by conftest.py (setup_lsp_mocks).
+LSP_SERVER patching uses the ``patched_lsp_server`` fixture which restores
+originals automatically via ``unittest.mock.patch.object``.
+"""
+
+import os
+from unittest.mock import patch
+
+import lsp_server
+
+
+# ---------------------------------------------------------------------------
+# log_to_output
+# ---------------------------------------------------------------------------
+def test_log_to_output_calls_window_log_message(patched_lsp_server):
+    """log_to_output uses the Pygls 2 window_log_message API."""
+    log_mock, show_mock = patched_lsp_server
+
+    lsp_server.log_to_output("hello")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# log_error
+# ---------------------------------------------------------------------------
+def test_log_error_always_logs(patched_lsp_server):
+    """log_error always calls window_log_message regardless of notification setting."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_error_shows_notification_on_error(patched_lsp_server):
+    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+def test_log_error_shows_notification_on_always(patched_lsp_server):
+    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# log_warning
+# ---------------------------------------------------------------------------
+def test_log_warning_no_notification_when_off(patched_lsp_server):
+    """log_warning does not show notification when LS_SHOW_NOTIFICATION=off."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_warning_no_notification_on_error_only(patched_lsp_server):
+    """log_warning does not show notification when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_warning_shows_notification_on_warning(patched_lsp_server):
+    """log_warning shows notification when LS_SHOW_NOTIFICATION=onWarning."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+def test_log_warning_shows_notification_on_always(patched_lsp_server):
+    """log_warning shows notification when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# log_always
+# ---------------------------------------------------------------------------
+def test_log_always_no_notification_when_off(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=off."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_no_notification_on_error(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_no_notification_on_warning(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=onWarning."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_shows_notification_on_always(patched_lsp_server):
+    """log_always shows notification only when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()

--- a/src/test/python_tests/test_stdlib_detection.py
+++ b/src/test/python_tests/test_stdlib_detection.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Tests for stdlib file detection.
+
+Verifies ``is_stdlib_file`` from ``lsp_utils`` correctly identifies
+standard-library and known Python paths vs. arbitrary user files.
+"""
+
+import os
+import site
+import sysconfig
+import tempfile
+
+from lsp_utils import is_stdlib_file
+
+
+def test_stdlib_file_detection():
+    """Actual stdlib files are correctly identified."""
+    os_file = os.__file__
+    assert is_stdlib_file(
+        os_file
+    ), f"os module file {os_file} should be detected as stdlib"
+
+
+def test_random_file_not_stdlib():
+    """Random user files are NOT identified as stdlib."""
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = is_stdlib_file(tmp_path)
+        assert not result, f"Temporary file {tmp_path} should NOT be detected as stdlib"
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_known_sysconfig_paths_detected():
+    """Files under sysconfig stdlib/platstdlib paths are detected."""
+    stdlib_path = sysconfig.get_path("stdlib")
+    if stdlib_path:
+        test_file = os.path.join(stdlib_path, "json", "__init__.py")
+        assert is_stdlib_file(
+            test_file
+        ), f"File under stdlib path {test_file} should be detected"
+
+
+def test_site_packages_in_stdlib_paths():
+    """In mypy, _stdlib_paths includes site-packages directories."""
+    site_packages = site.getsitepackages()
+
+    for site_pkg_dir in site_packages:
+        test_file = os.path.join(site_pkg_dir, "pytest", "__init__.py")
+        result = is_stdlib_file(test_file)
+        assert result, (
+            f"File in site-packages {test_file} should be detected "
+            f"(mypy _stdlib_paths includes site-packages)"
+        )
+
+
+def test_nonexistent_path_not_stdlib():
+    """A fabricated path outside all known Python directories is not stdlib."""
+    if os.name == "nt":
+        test_file = "Z:\\nonexistent\\random_dir\\module.py"
+    else:
+        test_file = "/nonexistent/random_dir/module.py"
+    assert not is_stdlib_file(
+        test_file
+    ), f"Fabricated path {test_file} should NOT be detected as stdlib"


### PR DESCRIPTION
Backport test files from flake8 that test shared infrastructure:
- test_logging.py: logging helpers and LS_SHOW_NOTIFICATION gating
- test_stdlib_detection.py: stdlib/site-packages file detection

These tests cover shared code that exists in all repos but was only tested in flake8.

Part of microsoft/vscode-python-tools-extension-template#290