### PR TITLE
test: parametrize logging, global_defaults, and diagnostic_regex tests

### DIFF
--- a/src/test/python_tests/test_diagnostic_regex.py
+++ b/src/test/python_tests/test_diagnostic_regex.py
@@ -1,18 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""
-Unit tests for diagnostic regex parsing in lsp_server.
+"""Unit tests for diagnostic regex parsing in lsp_server.
+
+Mock LSP dependencies and sys.path setup are provided by conftest.py.
 """
 
-import pathlib
-import sys
-
-# Add the bundled tool directory to sys.path for importing lsp_utils
-BUNDLED_TOOL_DIR = (
-    pathlib.Path(__file__).parent.parent.parent.parent / "bundled" / "tool"
-)
-sys.path.insert(0, str(BUNDLED_TOOL_DIR))
-from lsp_utils import DIAGNOSTIC_RE  # noqa: E402
+import pytest
+from lsp_utils import DIAGNOSTIC_RE
 
 
 def _get_group_dict(line: str):
@@ -23,119 +17,94 @@ def _get_group_dict(line: str):
     return None
 
 
-def test_diagnostic_regex_with_type_var_error():
-    """Test that [type-var] errors are correctly parsed."""
-    line = '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]'
-
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        pytest.param(
+            '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]',
+            {
+                "code": "type-var",
+                "message": 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"',
+                "line": "14",
+                "char": "16",
+                "end_line": "19",
+                "end_char": "5",
+                "type": "error",
+            },
+            id="type-var",
+        ),
+        pytest.param(
+            '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var] ',
+            {
+                "code": "type-var",
+                "message": 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"',
+            },
+            id="trailing-space",
+        ),
+        pytest.param(
+            '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]\t',
+            {
+                "code": "type-var",
+                "message": 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"',
+            },
+            id="trailing-tab",
+        ),
+        pytest.param(
+            '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]   ',
+            {
+                "code": "type-var",
+                "message": 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"',
+            },
+            id="trailing-multiple-spaces",
+        ),
+        pytest.param(
+            "/path/to/file.py:14:16: error: Some error message",
+            {
+                "code": None,
+                "message": "Some error message",
+                "line": "14",
+                "char": "16",
+            },
+            id="without-error-code",
+        ),
+        pytest.param(
+            '/path/to/file.py:2:6:2:7: error: Name "x" is not defined  [name-defined]',
+            {
+                "code": "name-defined",
+                "message": 'Name "x" is not defined',
+                "line": "2",
+                "char": "6",
+                "end_line": "2",
+                "end_char": "7",
+            },
+            id="name-defined",
+        ),
+        pytest.param(
+            "/path/to/file.py:5:10: note: See https://mypy.readthedocs.io/en/stable",
+            {
+                "type": "note",
+                "message": "See https://mypy.readthedocs.io/en/stable",
+                "code": None,
+            },
+            id="note-type",
+        ),
+        pytest.param(
+            "/path/to/file.py:10: error: Some error without column  [misc]",
+            {
+                "code": "misc",
+                "message": "Some error without column",
+                "line": "10",
+                "char": None,
+                "end_line": None,
+                "end_char": None,
+            },
+            id="without-column",
+        ),
+    ],
+)
+def test_diagnostic_regex_parsing(line, expected):
+    """DIAGNOSTIC_RE correctly extracts fields from mypy output lines."""
     data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the type-var error line"
-    assert data["code"] == "type-var", f"Expected code 'type-var', got {data['code']}"
-    assert (
-        data["message"]
-        == 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"'
-    ), f"Message should not include the error code, got: {data['message']}"
-    assert data["line"] == "14"
-    assert data["char"] == "16"
-    assert data["end_line"] == "19"
-    assert data["end_char"] == "5"
-    assert data["type"] == "error"
-
-
-def test_diagnostic_regex_with_trailing_space():
-    """Test that lines with trailing space after error code are correctly parsed."""
-    line = '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var] '
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the line with trailing space"
-    assert data["code"] == "type-var", f"Expected code 'type-var', got {data['code']}"
-    assert (
-        data["message"]
-        == 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"'
-    ), f"Message should not include the error code or trailing whitespace, got: {data['message']}"
-
-
-def test_diagnostic_regex_with_trailing_tab():
-    """Test that lines with trailing tab after error code are correctly parsed."""
-    line = '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]\t'
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the line with trailing tab"
-    assert data["code"] == "type-var", f"Expected code 'type-var', got {data['code']}"
-    assert (
-        data["message"]
-        == 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"'
-    ), f"Message should not include the error code or trailing whitespace, got: {data['message']}"
-
-
-def test_diagnostic_regex_with_multiple_trailing_spaces():
-    """Test that lines with multiple trailing spaces are correctly parsed."""
-    line = '/path/to/condition.py:14:16:19:5: error: Value of type variable "InstanceT" of "Metadata" cannot be "Condition"  [type-var]   '
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the line with multiple trailing spaces"
-    assert data["code"] == "type-var", f"Expected code 'type-var', got {data['code']}"
-    assert (
-        data["message"]
-        == 'Value of type variable "InstanceT" of "Metadata" cannot be "Condition"'
-    ), f"Message should not include the error code or trailing whitespace, got: {data['message']}"
-
-
-def test_diagnostic_regex_without_error_code():
-    """Test that lines without error code are correctly parsed."""
-    line = "/path/to/file.py:14:16: error: Some error message"
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the line without error code"
-    assert data["code"] is None, f"Expected code to be None, got {data['code']}"
-    assert data["message"] == "Some error message"
-    assert data["line"] == "14"
-    assert data["char"] == "16"
-
-
-def test_diagnostic_regex_with_name_defined_error():
-    """Test that [name-defined] errors are correctly parsed."""
-    line = '/path/to/file.py:2:6:2:7: error: Name "x" is not defined  [name-defined]'
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the name-defined error line"
-    assert (
-        data["code"] == "name-defined"
-    ), f"Expected code 'name-defined', got {data['code']}"
-    assert data["message"] == 'Name "x" is not defined'
-    assert data["line"] == "2"
-    assert data["char"] == "6"
-    assert data["end_line"] == "2"
-    assert data["end_char"] == "7"
-
-
-def test_diagnostic_regex_with_note_type():
-    """Test that note messages are correctly parsed."""
-    line = "/path/to/file.py:5:10: note: See https://mypy.readthedocs.io/en/stable"
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the note line"
-    assert data["type"] == "note"
-    assert data["message"] == "See https://mypy.readthedocs.io/en/stable"
-    assert data["code"] is None
-
-
-def test_diagnostic_regex_without_column():
-    """Test that lines without column numbers are correctly parsed."""
-    line = "/path/to/file.py:10: error: Some error without column  [misc]"
-
-    data = _get_group_dict(line)
-
-    assert data is not None, "Regex should match the line without column"
-    assert data["code"] == "misc"
-    assert data["message"] == "Some error without column"
-    assert data["line"] == "10"
-    assert data["char"] is None
-    assert data["end_line"] is None
-    assert data["end_char"] is None
+    assert data is not None, f"Regex should match: {line}"
+    for key, value in expected.items():
+        assert data[key] == value, f"Expected {key}={value!r}, got {data[key]!r}"

--- a/src/test/python_tests/test_global_defaults.py
+++ b/src/test/python_tests/test_global_defaults.py
@@ -8,6 +8,7 @@ per-workspace settings.
 """
 
 import lsp_server
+import pytest
 
 
 def _with_global_settings(overrides):
@@ -31,32 +32,39 @@ def _with_global_settings(overrides):
 # ---------------------------------------------------------------------------
 
 
-def test_global_defaults_ignorePatterns_from_global_settings():
-    """ignorePatterns set in GLOBAL_SETTINGS are returned by _get_global_defaults."""
-    with _with_global_settings({"ignorePatterns": ["*.pyi", "test_*"]}):
+@pytest.mark.parametrize(
+    "overrides, pop_key, key, expected",
+    [
+        pytest.param(
+            {"ignorePatterns": ["*.pyi", "test_*"]},
+            None,
+            "ignorePatterns",
+            ["*.pyi", "test_*"],
+            id="ignorePatterns-set",
+        ),
+        pytest.param(
+            {}, "ignorePatterns", "ignorePatterns", [], id="ignorePatterns-default"
+        ),
+        pytest.param(
+            {"daemonStatusFile": "/custom/status.json"},
+            None,
+            "daemonStatusFile",
+            "/custom/status.json",
+            id="daemonStatusFile-set",
+        ),
+        pytest.param(
+            {},
+            "daemonStatusFile",
+            "daemonStatusFile",
+            "",
+            id="daemonStatusFile-default",
+        ),
+    ],
+)
+def test_global_defaults_setting(overrides, pop_key, key, expected):
+    """Each global setting is correctly read or defaults when absent."""
+    with _with_global_settings(overrides):
+        if pop_key:
+            lsp_server.GLOBAL_SETTINGS.pop(pop_key, None)
         defaults = lsp_server._get_global_defaults()
-        assert defaults["ignorePatterns"] == ["*.pyi", "test_*"]
-
-
-def test_global_defaults_ignorePatterns_empty_when_not_set():
-    """ignorePatterns defaults to [] when not present in GLOBAL_SETTINGS."""
-    with _with_global_settings({}):
-        # Ensure ignorePatterns is not in GLOBAL_SETTINGS
-        lsp_server.GLOBAL_SETTINGS.pop("ignorePatterns", None)
-        defaults = lsp_server._get_global_defaults()
-        assert defaults["ignorePatterns"] == []
-
-
-def test_global_defaults_daemonStatusFile_from_global_settings():
-    """daemonStatusFile set in GLOBAL_SETTINGS is returned by _get_global_defaults."""
-    with _with_global_settings({"daemonStatusFile": "/custom/status.json"}):
-        defaults = lsp_server._get_global_defaults()
-        assert defaults["daemonStatusFile"] == "/custom/status.json"
-
-
-def test_global_defaults_daemonStatusFile_empty_when_not_set():
-    """daemonStatusFile defaults to '' when not present in GLOBAL_SETTINGS."""
-    with _with_global_settings({}):
-        lsp_server.GLOBAL_SETTINGS.pop("daemonStatusFile", None)
-        defaults = lsp_server._get_global_defaults()
-        assert defaults["daemonStatusFile"] == ""
+        assert defaults[key] == expected

--- a/src/test/python_tests/test_logging.py
+++ b/src/test/python_tests/test_logging.py
@@ -15,6 +15,7 @@ import os
 from unittest.mock import patch
 
 import lsp_server
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -31,130 +32,48 @@ def test_log_to_output_calls_window_log_message(patched_lsp_server):
 
 
 # ---------------------------------------------------------------------------
-# log_error
+# Notification gating (log_error / log_warning / log_always)
 # ---------------------------------------------------------------------------
-def test_log_error_always_logs(patched_lsp_server):
-    """log_error always calls window_log_message regardless of notification setting."""
+@pytest.mark.parametrize(
+    "log_func_name, message, notification_setting, expect_show",
+    [
+        pytest.param("log_error", "error occurred", "off", False, id="error-off"),
+        pytest.param(
+            "log_error", "error occurred", "onError", True, id="error-onError"
+        ),
+        pytest.param("log_error", "error occurred", "always", True, id="error-always"),
+        pytest.param("log_warning", "warning message", "off", False, id="warning-off"),
+        pytest.param(
+            "log_warning", "warning message", "onError", False, id="warning-onError"
+        ),
+        pytest.param(
+            "log_warning", "warning message", "onWarning", True, id="warning-onWarning"
+        ),
+        pytest.param(
+            "log_warning", "warning message", "always", True, id="warning-always"
+        ),
+        pytest.param("log_always", "info message", "off", False, id="always-off"),
+        pytest.param(
+            "log_always", "info message", "onError", False, id="always-onError"
+        ),
+        pytest.param(
+            "log_always", "info message", "onWarning", False, id="always-onWarning"
+        ),
+        pytest.param("log_always", "info message", "always", True, id="always-always"),
+    ],
+)
+def test_notification_gating(
+    patched_lsp_server, log_func_name, message, notification_setting, expect_show
+):
+    """Log functions always log; notifications are gated by LS_SHOW_NOTIFICATION."""
     log_mock, show_mock = patched_lsp_server
+    log_func = getattr(lsp_server, log_func_name)
 
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_error("error occurred")
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": notification_setting}):
+        log_func(message)
 
     log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_error_shows_notification_on_error(patched_lsp_server):
-    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_error("error occurred")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-def test_log_error_shows_notification_on_always(patched_lsp_server):
-    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_error("error occurred")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# log_warning
-# ---------------------------------------------------------------------------
-def test_log_warning_no_notification_when_off(patched_lsp_server):
-    """log_warning does not show notification when LS_SHOW_NOTIFICATION=off."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_warning_no_notification_on_error_only(patched_lsp_server):
-    """log_warning does not show notification when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_warning_shows_notification_on_warning(patched_lsp_server):
-    """log_warning shows notification when LS_SHOW_NOTIFICATION=onWarning."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-def test_log_warning_shows_notification_on_always(patched_lsp_server):
-    """log_warning shows notification when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# log_always
-# ---------------------------------------------------------------------------
-def test_log_always_no_notification_when_off(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=off."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_no_notification_on_error(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_no_notification_on_warning(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=onWarning."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_shows_notification_on_always(patched_lsp_server):
-    """log_always shows notification only when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
+    if expect_show:
+        show_mock.assert_called_once()
+    else:
+        show_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Pytest modernization Round 2 for mypy:

- **test_logging.py**: Collapse 11 notification-gating tests into 1 \@pytest.mark.parametrize\ test.
- **test_global_defaults.py**: Collapse 4 setting tests into 1 \@pytest.mark.parametrize\ test covering ignorePatterns/daemonStatusFile.
- **test_diagnostic_regex.py**: Collapse 8 regex tests into 1 \@pytest.mark.parametrize\ test + remove inline sys.path manipulation (conftest handles it).

Net: 23 → 3 test functions (same coverage).

Part of the pytest modernization effort (Phase 4.4e Round 2).