### PR TITLE
feat: wire vscode-common-python-lsp shared package (Stage 1)

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -84,8 +84,15 @@ __all__ = [
 
 
 def run_path(argv, cwd, env=None) -> RunResult:
-    """Runs as an executable (backward-compatible wrapper)."""
-    return _run_path(argv=argv, use_stdin=False, cwd=cwd, env=env)
+    """Runs as an executable (backward-compatible wrapper).
+
+    Mypy passes a partial env dict (extra vars only) — merge with os.environ
+    to preserve the full environment, matching the original behavior.
+    """
+    new_env = os.environ.copy()
+    if env is not None:
+        new_env.update(env)
+    return _run_path(argv=argv, use_stdin=False, cwd=cwd, env=new_env)
 
 
 def absolute_path(file_path: str) -> str:

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -1,27 +1,41 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""Utility functions and classes for use with running tools over LSP."""
+"""Utility functions and classes for use with running tools over LSP.
+
+Thin wrapper: delegates to vscode-common-python-lsp shared package,
+providing backward-compatible names used by lsp_server.py.
+"""
 
 from __future__ import annotations
 
-import contextlib
-import fnmatch
-import io
-import logging
 import os
 import pathlib
 import re
-import runpy
-import site
-import subprocess
-import sys
-import sysconfig
-import threading
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-# Save the working directory used when loading this module
-SERVER_CWD = os.getcwd()
-CWD_LOCK = threading.Lock()
+from vscode_common_python_lsp import (
+    CWD_LOCK,
+    SERVER_CWD,
+    CustomIO,
+    PythonFileKind,
+    QuickFixRegistrationError,
+    RunResult,
+    as_list,
+    change_cwd,
+    classify_python_file,
+    is_current_interpreter,
+    is_match,
+    is_same_path,
+    normalize_path,
+    redirect_io,
+    run_api,
+    run_module,
+    run_path as _run_path,
+    substitute_attr,
+)
+
+# -------------------------------------------------------------------------
+# Mypy-specific constants (not part of shared package)
+# -------------------------------------------------------------------------
 ERROR_CODE_BASE_URL = "https://mypy.readthedocs.io/en/latest/_refs.html#code-"
 SEE_HREF_PREFIX = "See https://mypy.readthedocs.io"
 SEE_PREFIX_LEN = len("See ")
@@ -38,62 +52,40 @@ DIAGNOSTIC_RE = re.compile(
     r"^(?P<location>(?P<filepath>..[^:]*):(?P<line>\d+)(?::(?P<char>\d+))?(?::(?P<end_line>\d+):(?P<end_char>\d+))?): (?P<type>\w+): (?P<message>.*?)(?:\s{2}\[(?P<code>[\w-]+)\])?\s*$"
 )
 
-
-def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:
-    """Ensures we always get a list"""
-    if isinstance(content, (list, tuple)):
-        return list(content)
-    return [content]
-
-
-def _get_sys_config_paths() -> List[str]:
-    """Returns paths from sysconfig.get_paths()."""
-    return [
-        path
-        for group, path in sysconfig.get_paths().items()
-        if group not in ["data", "platdata", "scripts"]
-    ]
-
-
-def _get_extensions_dir() -> List[str]:
-    """This is the extensions folder under ~/.vscode or ~/.vscode-server."""
-
-    # The path here is calculated relative to the tool
-    # this is because users can launch VS Code with custom
-    # extensions folder using the --extensions-dir argument
-    path = pathlib.Path(__file__).parent.parent.parent.parent
-    #                              ^     bundled  ^  extensions
-    #                            tool        <extension>
-    if path.name == "extensions":
-        return [os.fspath(path)]
-    return []
-
-
-_stdlib_paths = set(
-    str(pathlib.Path(p).resolve())
-    for p in (
-        as_list(site.getsitepackages())
-        + as_list(site.getusersitepackages())
-        + _get_sys_config_paths()
-        + _get_extensions_dir()
-    )
-)
+__all__ = [
+    "SERVER_CWD",
+    "CWD_LOCK",
+    "as_list",
+    "normalize_path",
+    "is_same_path",
+    "is_current_interpreter",
+    "is_user_site_packages_file",
+    "is_system_site_packages_file",
+    "is_stdlib_file",
+    "is_match",
+    "RunResult",
+    "CustomIO",
+    "substitute_attr",
+    "redirect_io",
+    "change_cwd",
+    "run_module",
+    "run_path",
+    "run_api",
+    "QuickFixRegistrationError",
+    "ERROR_CODE_BASE_URL",
+    "SEE_HREF_PREFIX",
+    "SEE_PREFIX_LEN",
+    "NOTE_CODE",
+    "LINE_OFFSET",
+    "CHAR_OFFSET",
+    "DIAGNOSTIC_RE",
+    "absolute_path",
+]
 
 
-def normalize_path(file_path: str, resolve_symlinks: bool = True) -> str:
-    """Returns normalized path."""
-    path = pathlib.Path(file_path)
-    if resolve_symlinks:
-        path = path.resolve()
-    return str(path)
-
-
-def is_same_path(file_path1: str, file_path2: str) -> bool:
-    """Returns true if two paths are the same, resolving symlinks."""
-    try:
-        return pathlib.Path(file_path1).resolve() == pathlib.Path(file_path2).resolve()
-    except OSError:
-        return pathlib.Path(file_path1) == pathlib.Path(file_path2)
+def run_path(argv, cwd, env=None) -> RunResult:
+    """Runs as an executable (backward-compatible wrapper)."""
+    return _run_path(argv=argv, use_stdin=False, cwd=cwd, env=env)
 
 
 def absolute_path(file_path: str) -> str:
@@ -101,203 +93,16 @@ def absolute_path(file_path: str) -> str:
     return str(pathlib.Path(file_path).absolute())
 
 
-def is_current_interpreter(executable: str) -> bool:
-    """Returns true if the executable path is same as the current interpreter."""
-    return is_same_path(executable, sys.executable)
+def is_user_site_packages_file(file_path: str) -> bool:
+    """Return True if the file belongs to the user site-packages directory."""
+    return classify_python_file(file_path) == PythonFileKind.USER_SITE
+
+
+def is_system_site_packages_file(file_path: str) -> bool:
+    """Return True if the file belongs to system site-packages directories."""
+    return classify_python_file(file_path) == PythonFileKind.SYSTEM_SITE
 
 
 def is_stdlib_file(file_path: str) -> bool:
-    """Return True if the file belongs to the standard library."""
-    normalized_path = str(pathlib.Path(file_path).resolve())
-    return any(normalized_path.startswith(path) for path in _stdlib_paths)
-
-
-def _get_relative_path(file_path: str, workspace_root: str) -> str:
-    """Returns the file path relative to the workspace root.
-
-    Falls back to the original path if the workspace root is empty or
-    the paths are on different drives (Windows).
-    """
-    if not workspace_root:
-        return pathlib.Path(file_path).as_posix()
-    try:
-        return pathlib.Path(file_path).relative_to(workspace_root).as_posix()
-    except ValueError:
-        return pathlib.Path(file_path).as_posix()
-
-
-def is_match(patterns: List[str], file_path: str, workspace_root: str = None) -> bool:
-    """Returns true if the file matches one of the fnmatch patterns."""
-    if not patterns:
-        return False
-    relative_path = (
-        _get_relative_path(file_path, workspace_root) if workspace_root else file_path
-    )
-    file_name = pathlib.Path(file_path).name
-    return any(
-        fnmatch.fnmatch(relative_path, pattern)
-        or (not pattern.startswith("/") and fnmatch.fnmatch(file_name, pattern))
-        for pattern in patterns
-    )
-
-
-# pylint: disable-next=too-few-public-methods
-class RunResult:
-    """Object to hold result from running tool."""
-
-    def __init__(
-        self, stdout: str, stderr: str, exit_code: Optional[Union[int, str]] = None
-    ):
-        self.stdout: str = stdout
-        self.stderr: str = stderr
-        self.exit_code: Optional[Union[int, str]] = exit_code
-
-
-class CustomIO(io.TextIOWrapper):
-    """Custom stream object to replace stdio."""
-
-    name = None
-
-    def __init__(self, name, encoding="utf-8", newline=None):
-        self._buffer = io.BytesIO()
-        self._buffer.name = name
-        super().__init__(self._buffer, encoding=encoding, newline=newline)
-
-    def close(self):
-        """Provide this close method which is used by some tools."""
-        # This is intentionally empty.
-
-    def get_value(self) -> str:
-        """Returns value from the buffer as string."""
-        self.seek(0)
-        return self.read()
-
-
-@contextlib.contextmanager
-def substitute_attr(obj: Any, attribute: str, new_value: Any):
-    """Manage object attributes context when using runpy.run_module()."""
-    old_value = getattr(obj, attribute)
-    setattr(obj, attribute, new_value)
-    yield
-    setattr(obj, attribute, old_value)
-
-
-@contextlib.contextmanager
-def redirect_io(stream: str, new_stream):
-    """Redirect stdio streams to a custom stream."""
-    old_stream = getattr(sys, stream)
-    setattr(sys, stream, new_stream)
-    yield
-    setattr(sys, stream, old_stream)
-
-
-@contextlib.contextmanager
-def change_cwd(new_cwd):
-    """Change working directory before running code."""
-    try:
-        os.chdir(new_cwd)
-    except OSError as e:
-        logging.warning(
-            "Failed to change directory to %r, running in %r instead: %s",
-            new_cwd,
-            SERVER_CWD,
-            e,
-        )
-        yield
-        return
-    try:
-        yield
-    finally:
-        os.chdir(SERVER_CWD)
-
-
-def _run_module(
-    module: str, argv: Sequence[str], use_stdin: bool, source: str = None
-) -> RunResult:
-    """Runs as a module."""
-    str_output = CustomIO("<stdout>", encoding="utf-8")
-    str_error = CustomIO("<stderr>", encoding="utf-8")
-    exit_code = None
-
-    try:
-        with substitute_attr(sys, "argv", argv):
-            with redirect_io("stdout", str_output):
-                with redirect_io("stderr", str_error):
-                    if use_stdin and source is not None:
-                        str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                        with redirect_io("stdin", str_input):
-                            str_input.write(source)
-                            str_input.seek(0)
-                            runpy.run_module(module, run_name="__main__")
-                    else:
-                        runpy.run_module(module, run_name="__main__")
-    except SystemExit as ex:
-        exit_code = ex.code
-
-    return RunResult(str_output.get_value(), str_error.get_value(), exit_code)
-
-
-def run_module(
-    module: str, argv: Sequence[str], use_stdin: bool, cwd: str, source: str = None
-) -> RunResult:
-    """Runs as a module."""
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_module(module, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_module(module, argv, use_stdin, source)
-
-
-def run_path(argv: Sequence[str], cwd: str, env: Dict[str, str] = None) -> RunResult:
-    """Runs as an executable."""
-    new_env = os.environ.copy()
-    if env is not None:
-        new_env.update(env)
-    result = subprocess.run(
-        argv,
-        encoding="utf-8",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-        cwd=cwd,
-        env=new_env,
-    )
-    return RunResult(result.stdout, result.stderr, result.returncode)
-
-
-def run_api(
-    callback: Callable[[Sequence[str], Optional[CustomIO]], Tuple[str, str, int]],
-    argv: Sequence[str],
-    use_stdin: bool,
-    cwd: str,
-    source: str = None,
-) -> RunResult:
-    """Run a API."""
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_api(callback, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_api(callback, argv, use_stdin, source)
-
-
-def _run_api(
-    callback: Callable[[Sequence[str], Optional[CustomIO]], Tuple[str, str, int]],
-    argv: Sequence[str],
-    use_stdin: bool,
-    source: str = None,
-) -> RunResult:
-    str_output = None
-    str_error = None
-
-    with contextlib.suppress(SystemExit):
-        with substitute_attr(sys, "argv", argv):
-            if use_stdin and source is not None:
-                str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                with redirect_io("stdin", str_input):
-                    str_input.write(source)
-                    str_input.seek(0)
-                    str_output, str_error, exit_code = callback(argv, str_input)
-            else:
-                str_output, str_error, exit_code = callback(argv, None)
-
-    return RunResult(str_output, str_error, exit_code)
+    """Return True if the file belongs to a non-user Python path."""
+    return classify_python_file(file_path) is not None

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -24,12 +24,16 @@ from vscode_common_python_lsp import (
     classify_python_file,
     is_current_interpreter,
     is_match,
-    is_same_path,
+)
+from vscode_common_python_lsp import is_same_path as _is_same_path
+from vscode_common_python_lsp import (
     normalize_path,
     redirect_io,
     run_api,
     run_module,
-    run_path as _run_path,
+)
+from vscode_common_python_lsp import run_path as _run_path
+from vscode_common_python_lsp import (
     substitute_attr,
 )
 
@@ -93,6 +97,11 @@ def run_path(argv, cwd, env=None) -> RunResult:
     if env is not None:
         new_env.update(env)
     return _run_path(argv=argv, use_stdin=False, cwd=cwd, env=new_env)
+
+
+def is_same_path(file_path1: str, file_path2: str) -> bool:
+    """Returns true if two paths are the same, resolving symlinks."""
+    return _is_same_path(file_path1, file_path2, resolve_symlinks=True)
 
 
 def absolute_path(file_path: str) -> str:

--- a/noxfile.py
+++ b/noxfile.py
@@ -119,6 +119,16 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    session.install(
+        "-t",
+        "./bundled/libs",
+        "--no-cache-dir",
+        "--implementation",
+        "py",
+        "--no-deps",
+        "--upgrade",
+        "vscode-common-python-lsp==0.3.0",
+    )
 
 
 @nox.session(python="3.10")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "mypy-type-checker",
-    "version": "2026.3.0-dev",
+    "version": "2026.5.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mypy-type-checker",
-            "version": "2026.3.0-dev",
+            "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
+                "@vscode/common-python-lsp": "0.2.1",
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
                 "dotenv": "^17.4.1",
@@ -1293,6 +1294,75 @@
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/@vscode/common-python-lsp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.2.1.tgz",
+            "integrity": "sha512-FNYU9DCwa4InI6bGkmALw0JcEMEytRD2hp9wz3PNZ7pV1qtVB/Uvhj3rxr0fe9S9iXB4+GPF/tiF+xVmLhGQIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/@vscode/common-python-lsp/node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+            "license": "MIT"
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",
@@ -3510,9 +3580,9 @@
             "optional": true
         },
         "node_modules/fs-extra": {
-            "version": "11.3.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-            "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+            "version": "11.3.4",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+            "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
         ]
     },
     "dependencies": {
+        "@vscode/common-python-lsp": "0.2.1",
         "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/python-extension": "^1.0.6",
         "dotenv": "^17.4.1",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import { ToolConfig } from '@vscode/common-python-lsp';
 
 const folderName = path.basename(__dirname);
 export const EXTENSION_ROOT_DIR =
@@ -14,3 +15,39 @@ export const PYTHON_MINOR = 10;
 export const PYTHON_VERSION = `${PYTHON_MAJOR}.${PYTHON_MINOR}`;
 export const LS_SERVER_RESTART_DELAY = 1000;
 export const MYPY_CONFIG_FILES = ['mypy.ini', '.mypy.ini', 'pyproject.toml', 'setup.cfg'];
+
+export const MYPY_TOOL_CONFIG: ToolConfig = {
+    toolId: 'mypy-type-checker',
+    toolDisplayName: 'Mypy',
+    toolModule: 'mypy',
+    minimumPythonVersion: { major: PYTHON_MAJOR, minor: PYTHON_MINOR },
+    configFiles: MYPY_CONFIG_FILES,
+    serverScript: SERVER_SCRIPT_PATH,
+    debugServerScript: DEBUG_SERVER_SCRIPT_PATH,
+    settingsDefaults: {
+        args: [],
+        cwd: '${workspaceFolder}',
+        path: [],
+        ignorePatterns: [],
+        importStrategy: 'useBundled',
+        showNotifications: 'off',
+        extraPaths: [],
+        reportingScope: 'file',
+        preferDaemon: false,
+        severity: { error: 'Error', note: 'Information' },
+    },
+    trackedSettings: [
+        'args',
+        'cwd',
+        'severity',
+        'path',
+        'interpreter',
+        'importStrategy',
+        'showNotifications',
+        'reportingScope',
+        'preferDaemon',
+        'ignorePatterns',
+        'daemonStatusFile',
+        'extraPaths',
+    ],
+};

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,93 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as fsapi from 'fs-extra';
-import { Disposable, env, l10n, LanguageStatusSeverity, LogOutputChannel, Uri } from 'vscode';
-import { State } from 'vscode-languageclient';
+import { Disposable, LogOutputChannel } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
 import {
-    LanguageClient,
-    LanguageClientOptions,
-    RevealOutputChannelOn,
-    ServerOptions,
-} from 'vscode-languageclient/node';
-import { DEBUG_SERVER_SCRIPT_PATH, SERVER_SCRIPT_PATH } from './constants';
-import { getEnvFileVars } from './envFile';
-import { traceError, traceInfo, traceVerbose } from './logging';
-import { getDebuggerPath } from './python';
-import { getExtensionSettings, getGlobalSettings, ISettings } from './settings';
-import { getLSClientTraceLevel, getDocumentSelector } from './utilities';
-import { updateStatus } from './status';
-import { getWorkspaceFolder } from './vscodeapi';
+    IBaseSettings,
+    PythonEnvironmentsProvider,
+    getServerCwd as _getServerCwd,
+    restartServer as _restartServer,
+} from '@vscode/common-python-lsp';
+import { MYPY_TOOL_CONFIG } from './constants';
+import { traceError } from './logging';
+import { ISettings } from './settings';
 
 export type IInitOptions = { settings: ISettings[]; globalSettings: ISettings };
 
-async function createServer(
-    settings: ISettings,
-    serverId: string,
-    serverName: string,
-    outputChannel: LogOutputChannel,
-    initializationOptions: IInitOptions,
-): Promise<LanguageClient> {
-    const command = settings.interpreter[0];
-    let cwd: string;
-    if (settings.cwd === '${fileDirname}') {
-        cwd = Uri.parse(settings.workspace).fsPath;
-    } else if (settings.cwd === '${nearestConfig}') {
-        cwd = Uri.parse(settings.workspace).fsPath;
-    } else {
-        cwd = settings.cwd;
-    }
-
-    if (!fsapi.existsSync(cwd)) {
-        traceError(`Server cwd ${cwd} doesn't exist, server startup will probably fail`);
-    }
-
-    // Load env file vars and merge with process env
-    const workspaceFolder = getWorkspaceFolder(Uri.parse(settings.workspace));
-    const envFileVars = workspaceFolder ? await getEnvFileVars(workspaceFolder) : {};
-    const newEnv = { ...process.env, ...envFileVars };
-    const debuggerPath = await getDebuggerPath();
-    const isDebugScript = await fsapi.pathExists(DEBUG_SERVER_SCRIPT_PATH);
-    if (newEnv.USE_DEBUGPY && debuggerPath) {
-        newEnv.DEBUGPY_PATH = debuggerPath;
-    } else {
-        newEnv.USE_DEBUGPY = 'False';
-    }
-
-    // Set import strategy
-    newEnv.LS_IMPORT_STRATEGY = settings.importStrategy;
-
-    // Set notification type
-    newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
-
-    newEnv.PYTHONUTF8 = '1';
-
-    const args =
-        newEnv.USE_DEBUGPY === 'False' || !isDebugScript
-            ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])
-            : settings.interpreter.slice(1).concat([DEBUG_SERVER_SCRIPT_PATH]);
-    traceInfo(`Server run command: ${[command, ...args].join(' ')}`);
-
-    const serverOptions: ServerOptions = {
-        command,
-        args,
-        options: { cwd, env: newEnv },
-    };
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-        // Register the server for python documents
-        documentSelector: getDocumentSelector(),
-        outputChannel: outputChannel,
-        traceOutputChannel: outputChannel,
-        revealOutputChannelOn: RevealOutputChannelOn.Never,
-        initializationOptions,
-    };
-
-    return new LanguageClient(serverId, serverName, serverOptions, clientOptions);
+export function getServerCwd(settings: ISettings): string {
+    return _getServerCwd(settings as unknown as IBaseSettings);
 }
 
 let _disposables: Disposable[] = [];
+let _pythonProvider: PythonEnvironmentsProvider | undefined;
+
+function getPythonProvider(): PythonEnvironmentsProvider {
+    if (!_pythonProvider) {
+        _pythonProvider = new PythonEnvironmentsProvider(MYPY_TOOL_CONFIG);
+    }
+    return _pythonProvider;
+}
+
 export async function restartServer(
     workspaceSetting: ISettings,
     serverId: string,
@@ -95,47 +36,27 @@ export async function restartServer(
     outputChannel: LogOutputChannel,
     oldLsClient?: LanguageClient,
 ): Promise<LanguageClient | undefined> {
-    if (oldLsClient) {
-        traceInfo(`Server: Stop requested`);
+    _disposables.forEach((d) => {
         try {
-            await oldLsClient.stop();
+            d.dispose();
         } catch (ex) {
-            traceError(`Server: Stop failed: ${ex}`);
+            traceError(`Failed to dispose: ${ex}`);
         }
-    }
-    _disposables.forEach((d) => d.dispose());
-    _disposables = [];
-    updateStatus(undefined, LanguageStatusSeverity.Information, true);
-
-    const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {
-        settings: await getExtensionSettings(serverId, true),
-        globalSettings: await getGlobalSettings(serverId, false),
     });
+    _disposables = [];
 
-    traceInfo(`Server: Start requested.`);
-    _disposables.push(
-        newLSClient.onDidChangeState((e) => {
-            switch (e.newState) {
-                case State.Stopped:
-                    traceVerbose(`Server State: Stopped`);
-                    break;
-                case State.Starting:
-                    traceVerbose(`Server State: Starting`);
-                    break;
-                case State.Running:
-                    traceVerbose(`Server State: Running`);
-                    updateStatus(undefined, LanguageStatusSeverity.Information, false);
-                    break;
-            }
-        }),
+    const result = await _restartServer(
+        {
+            settings: workspaceSetting as unknown as IBaseSettings,
+            serverId,
+            serverName,
+            outputChannel,
+            toolConfig: MYPY_TOOL_CONFIG,
+            pythonProvider: getPythonProvider(),
+        },
+        oldLsClient as any,
     );
-    try {
-        await newLSClient.start();
-        await newLSClient.setTrace(getLSClientTraceLevel(outputChannel.logLevel, env.logLevel));
-    } catch (ex) {
-        updateStatus(l10n.t('Server failed to start.'), LanguageStatusSeverity.Error);
-        traceError(`Server: Start failed: ${ex}`);
-    }
 
-    return newLSClient;
+    _disposables = result.disposables;
+    return result.client as unknown as LanguageClient | undefined;
 }

--- a/src/test/python_tests/conftest.py
+++ b/src/test/python_tests/conftest.py
@@ -95,50 +95,78 @@ def setup_lsp_mocks():
             self._kwargs = kwargs
 
     for _name in [
+        "CodeAction",
+        "CodeActionOptions",
+        "CodeActionParams",
         "CodeDescription",
         "Diagnostic",
         "DiagnosticSeverity",
         "DidCloseTextDocumentParams",
         "DidOpenTextDocumentParams",
         "DidSaveTextDocumentParams",
+        "DidChangeNotebookDocumentParams",
+        "DidCloseNotebookDocumentParams",
+        "DidOpenNotebookDocumentParams",
+        "DidSaveNotebookDocumentParams",
         "DocumentFormattingParams",
         "InitializeParams",
         "LogMessageParams",
+        "NotebookCellKind",
+        "NotebookCellLanguage",
+        "NotebookDocumentFilterWithNotebook",
+        "NotebookDocumentSyncOptions",
         "Position",
         "PublishDiagnosticsParams",
         "Range",
         "ShowMessageParams",
+        "TextDocumentEdit",
         "TextEdit",
+        "TraceValue",
+        "VersionedTextDocumentIdentifier",
+        "WorkspaceEdit",
     ]:
         setattr(mock_lsp, _name, _FlexClass)
     mock_lsp.MessageType = types.SimpleNamespace(
         Log=4, Error=1, Warning=2, Info=3, Debug=5
     )
 
+    mock_pygls = types.ModuleType("pygls")
+    mock_pygls.__path__ = []
+    mock_pygls_lsp = types.ModuleType("pygls.lsp")
+    mock_pygls_lsp.__path__ = []
+    mock_lsprotocol = types.ModuleType("lsprotocol")
+    mock_lsprotocol.__path__ = []
+
     for _mod_name, _mod in [
-        ("pygls", types.ModuleType("pygls")),
-        ("pygls.lsp", types.ModuleType("pygls.lsp")),
+        ("pygls", mock_pygls),
+        ("pygls.lsp", mock_pygls_lsp),
         ("pygls.lsp.server", mock_lsp_server_mod),
         ("pygls.workspace", mock_workspace),
         ("pygls.uris", mock_uris),
-        ("lsprotocol", types.ModuleType("lsprotocol")),
+        ("lsprotocol", mock_lsprotocol),
         ("lsprotocol.types", mock_lsp),
     ]:
-        try:
-            __import__(_mod_name)
-        except ImportError:
+        if _mod_name not in sys.modules:
             sys.modules[_mod_name] = _mod
             _INJECTED_MODULES.append(_mod_name)
 
-    # lsp_utils delegates to vscode-common-python-lsp which lives in bundled/libs.
-    libs_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "libs")
-    if libs_dir not in sys.path:
-        sys.path.insert(0, libs_dir)
+    pygls_mod = sys.modules["pygls"]
+    pygls_lsp_mod = sys.modules["pygls.lsp"]
+    pygls_mod.lsp = pygls_lsp_mod
+    pygls_mod.workspace = sys.modules["pygls.workspace"]
+    pygls_mod.uris = sys.modules["pygls.uris"]
+    pygls_lsp_mod.server = sys.modules["pygls.lsp.server"]
 
     tool_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "tool")
     if tool_dir not in sys.path:
         sys.path.insert(0, tool_dir)
         _INJECTED_PATH = tool_dir
+
+    # Add bundled/libs so the shared vscode_common_python_lsp package
+    # is importable (installed there by nox install_bundled_libs).
+    libs_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "libs")
+    if libs_dir not in sys.path:
+        sys.path.insert(0, libs_dir)
 
 
 # Run at import time so test modules can ``import lsp_server`` at the top level.

--- a/src/test/python_tests/conftest.py
+++ b/src/test/python_tests/conftest.py
@@ -130,8 +130,10 @@ def setup_lsp_mocks():
             sys.modules[_mod_name] = _mod
             _INJECTED_MODULES.append(_mod_name)
 
-    # lsp_utils lives in bundled/tool and only uses stdlib —
-    # let the real module be imported so tests are not broken by a partial mock.
+    # lsp_utils delegates to vscode-common-python-lsp which lives in bundled/libs.
+    libs_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "libs")
+    if libs_dir not in sys.path:
+        sys.path.insert(0, libs_dir)
 
     tool_dir = str(pathlib.Path(__file__).parents[3] / "bundled" / "tool")
     if tool_dir not in sys.path:


### PR DESCRIPTION
## Summary

Wires the `vscode-common-python-lsp` shared package into the extension (Stage 1).

## Changes

- **Python**: Replace `lsp_utils.py` with thin wrapper delegating to shared package, keeping mypy-specific constants (`DIAGNOSTIC_RE`, `ERROR_CODE_BASE_URL`, etc.) local
- **TypeScript**: Add `ToolConfig` to `constants.ts`, replace `server.ts` with shared-package delegation
- **Dependencies**: Add shared package (npm `@vscode/common-python-lsp@0.2.1` + PyPI `vscode-common-python-lsp==0.3.0` bundled)
- **Tests**: Update `conftest.py` to include `bundled/libs` in `sys.path`

Zero behavioral changes. All unit tests pass.