### PR TITLE
fix: include shared LSP package in bundled requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@
 pygls
 packaging
 mypy
+vscode-common-python-lsp==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,9 @@ packaging==24.2 \
 pygls==2.0.1 \
     --hash=sha256:2f774a669fbe2ece977d302786f01f9b0c5df7d0204ea0fa371ecb08288d6b86 \
     --hash=sha256:d29748042cea5bedc98285eb3e2c0c60bf3fc73786319519001bf72bbe8f36cc
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   vscode-common-python-lsp
 tomli==2.2.1 \
     --hash=sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6 \
     --hash=sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd \
@@ -107,3 +109,6 @@ typing-extensions==4.12.2 \
     # via
     #   cattrs
     #   mypy
+vscode-common-python-lsp==0.5.1 \
+    --hash=sha256:8d787f0200035c4f340bcdf785f2b347c97036d449f42910c35ee3ee68bcb653
+    # via -r requirements.in

--- a/src/test/python_tests/test_packaging.py
+++ b/src/test/python_tests/test_packaging.py
@@ -10,6 +10,7 @@ accidentally excluded.
 """
 
 import importlib.metadata
+import importlib.util
 import pathlib
 import sys
 
@@ -36,3 +37,10 @@ def test_mypy_metadata_version():
     assert version, "mypy version string should not be empty"
     parts = version.split(".")
     assert len(parts) >= 2, f"Unexpected version format: {version}"
+
+
+def test_common_lsp_package_is_bundled():
+    """The server imports this package before it can start."""
+    spec = importlib.util.find_spec("vscode_common_python_lsp")
+    assert spec is not None
+    assert pathlib.Path(spec.origin).is_relative_to(BUNDLED_LIBS)


### PR DESCRIPTION
## Summary
- add `vscode-common-python-lsp==0.5.1` to the bundled Python requirements so VSIX builds that install from `requirements.txt` include the shared LSP package
- add a packaging regression that verifies `vscode_common_python_lsp` resolves from `bundled/libs`

Closes #551.

## Testing
- inspected the Open VSX `ms-python.mypy-type-checker-2026.6.0.vsix`: no `vscode_common_python_lsp` package entries
- `python -m pip install -t ./bundled/libs --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt`
- `python -m pytest src/test/python_tests/test_packaging.py -q`
- `python -m py_compile noxfile.py src\test\python_tests\test_packaging.py`
- `npm run vsce-package`
- inspected the built `mypy.vsix`: `vscode_common_python_lsp` entries present