### PR TITLE
refactor: use shared package APIs for settings and lsp_server

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import copy
-import json
 import os
 import pathlib
 import sys
@@ -50,15 +49,14 @@ from pygls.lsp.server import LanguageServer
 from pygls.workspace import TextDocument
 from vscode_common_python_lsp import (
     RunResult,
+    ToolServer,
+    ToolServerConfig,
     is_match,
     normalize_path,
     update_environ_path,
 )
 
 update_environ_path()
-
-WORKSPACE_SETTINGS = {}
-GLOBAL_SETTINGS = {}
 
 MAX_WORKERS = 5
 LSP_SERVER = LanguageServer(name="Mypy", version="v0.1.0", max_workers=MAX_WORKERS)
@@ -69,17 +67,40 @@ DMYPY_STATUS_FILE_ROOT = None
 # **********************************************************
 # Tool specific code goes below this.
 # **********************************************************
-TOOL_MODULE = "mypy"
-TOOL_DISPLAY = "Mypy"
-TOOL_ARGS = [
-    "--no-color-output",
-    "--no-error-summary",
-    "--show-absolute-path",
-    "--show-column-numbers",
-    "--show-error-codes",
-    "--no-pretty",
-]
-MIN_VERSION = "1.0.0"
+MYPY_CONFIG = ToolServerConfig(
+    tool_module="mypy",
+    tool_display="Mypy",
+    tool_args=[
+        "--no-color-output",
+        "--no-error-summary",
+        "--show-absolute-path",
+        "--show-column-numbers",
+        "--show-error-codes",
+        "--no-pretty",
+    ],
+    min_version="1.0.0",
+    default_settings={
+        "severity": {
+            "error": "Error",
+            "note": "Information",
+        },
+        "ignorePatterns": [],
+        "extraPaths": [],
+        "reportingScope": "file",
+        "preferDaemon": True,
+        "daemonStatusFile": "",
+    },
+)
+
+tool_server = ToolServer(MYPY_CONFIG, server=LSP_SERVER)
+
+WORKSPACE_SETTINGS = tool_server.workspace_settings
+GLOBAL_SETTINGS = tool_server.global_settings
+
+TOOL_MODULE = MYPY_CONFIG.tool_module
+TOOL_DISPLAY = MYPY_CONFIG.tool_display
+TOOL_ARGS = MYPY_CONFIG.tool_args
+MIN_VERSION = MYPY_CONFIG.min_version
 
 # **********************************************************
 # Linting features start here
@@ -467,28 +488,17 @@ def _get_severity(
 @LSP_SERVER.feature(lsp.INITIALIZE)
 def initialize(params: lsp.InitializeParams) -> None:
     """LSP handler for initialize request."""
-    log_to_output(f"CWD Server: {os.getcwd()}")
     import_strategy = os.getenv("LS_IMPORT_STRATEGY", "useBundled")
     update_sys_path(os.getcwd(), import_strategy)
-
-    GLOBAL_SETTINGS.update(**params.initialization_options.get("globalSettings", {}))
-
-    settings = params.initialization_options["settings"]
-    _update_workspace_settings(settings)
-    log_to_output(
-        f"Settings used to run Server:\r\n{json.dumps(settings, indent=4, ensure_ascii=False)}\r\n"
-    )
-    log_to_output(
-        f"Global settings:\r\n{json.dumps(GLOBAL_SETTINGS, indent=4, ensure_ascii=False)}\r\n"
-    )
+    tool_server.apply_settings(params)
+    settings = (params.initialization_options or {}).get("settings")
 
     # Add extra paths to sys.path
-    setting = _get_settings_by_path(pathlib.Path(os.getcwd()))
+    setting = tool_server.get_settings_by_path(pathlib.Path(os.getcwd()))
     for extra in setting.get("extraPaths", []):
         update_sys_path(extra, import_strategy)
 
-    paths = "\r\n   ".join(sys.path)
-    log_to_output(f"sys.path used to run Server:\r\n   {paths}")
+    tool_server.log_startup_info(settings)
 
     global DMYPY_STATUS_FILE_ROOT
     if "DMYPY_STATUS_FILE_ROOT" in os.environ:
@@ -557,92 +567,26 @@ def _log_version_info() -> None:
 
 # *****************************************************
 # Internal functional and settings management APIs.
+# Thin wrappers delegating to ToolServer for backward compatibility.
 # *****************************************************
 def _get_global_defaults():
-    return {
-        "path": GLOBAL_SETTINGS.get("path", []),
-        "interpreter": GLOBAL_SETTINGS.get("interpreter", [sys.executable]),
-        "args": GLOBAL_SETTINGS.get("args", []),
-        "severity": GLOBAL_SETTINGS.get(
-            "severity",
-            {
-                "error": "Error",
-                "note": "Information",
-            },
-        ),
-        "ignorePatterns": GLOBAL_SETTINGS.get("ignorePatterns", []),
-        "importStrategy": GLOBAL_SETTINGS.get("importStrategy", "useBundled"),
-        "showNotifications": GLOBAL_SETTINGS.get("showNotifications", "off"),
-        "extraPaths": GLOBAL_SETTINGS.get("extraPaths", []),
-        "reportingScope": GLOBAL_SETTINGS.get("reportingScope", "file"),
-        "preferDaemon": GLOBAL_SETTINGS.get("preferDaemon", True),
-        "daemonStatusFile": GLOBAL_SETTINGS.get("daemonStatusFile", ""),
-    }
+    return tool_server.get_global_defaults()
 
 
 def _update_workspace_settings(settings):
-    if not settings:
-        key = normalize_path(os.getcwd())
-        WORKSPACE_SETTINGS[key] = {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-        return
-
-    for setting in settings:
-        key = normalize_path(uris.to_fs_path(setting["workspace"]))
-        WORKSPACE_SETTINGS[key] = {
-            **setting,
-            "workspaceFS": key,
-        }
+    tool_server.update_workspace_settings(settings)
 
 
 def _get_settings_by_path(file_path: pathlib.Path):
-    workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-    while file_path != file_path.parent:
-        str_file_path = normalize_path(file_path)
-        if str_file_path in workspaces:
-            return WORKSPACE_SETTINGS[str_file_path]
-        file_path = file_path.parent
-
-    setting_values = list(WORKSPACE_SETTINGS.values())
-    return setting_values[0]
+    return tool_server.get_settings_by_path(file_path)
 
 
 def _get_document_key(document: TextDocument):
-    if WORKSPACE_SETTINGS:
-        document_workspace = pathlib.Path(document.path)
-        workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-        # Find workspace settings for the given file.
-        while document_workspace != document_workspace.parent:
-            norm_path = normalize_path(document_workspace)
-            if norm_path in workspaces:
-                return norm_path
-            document_workspace = document_workspace.parent
-
-    return None
+    return tool_server.get_document_key(document)
 
 
 def _get_settings_by_document(document: TextDocument | None):
-    if document is None or document.path is None:
-        return list(WORKSPACE_SETTINGS.values())[0]
-
-    key = _get_document_key(document)
-    if key is None:
-        # This is either a non-workspace file or there is no workspace.
-        key = normalize_path(pathlib.Path(document.path).parent)
-        return {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-
-    return WORKSPACE_SETTINGS[str(key)]
+    return tool_server.get_settings_by_document(document)
 
 
 # *****************************************************
@@ -774,33 +718,7 @@ def get_cwd(settings: Dict[str, Any], document: Optional[TextDocument]) -> str:
             )
             return workspace_fs
 
-    if document and document.path:
-        file_path = document.path
-        file_dir = os.path.dirname(file_path)
-        file_basename = os.path.basename(file_path)
-        file_stem, file_ext = os.path.splitext(file_basename)
-
-        substitutions = {
-            "${file}": file_path,
-            "${fileBasename}": file_basename,
-            "${fileBasenameNoExtension}": file_stem,
-            "${fileExtname}": file_ext,
-            "${fileDirname}": file_dir,
-            "${fileDirnameBasename}": os.path.basename(file_dir),
-            "${relativeFile}": os.path.relpath(file_path, workspace_fs),
-            "${relativeFileDirname}": os.path.relpath(file_dir, workspace_fs),
-            "${fileWorkspaceFolder}": workspace_fs,
-        }
-
-        for token, value in substitutions.items():
-            cwd = cwd.replace(token, value)
-    else:
-        # Without a document we cannot resolve file-related variables.
-        # Fall back to workspace root if any remain.
-        if "${file" in cwd or "${relativeFile" in cwd:
-            cwd = workspace_fs
-
-    return cwd
+    return tool_server.get_cwd(settings, document)
 
 
 def _run_tool_on_document(
@@ -816,7 +734,7 @@ def _run_tool_on_document(
         extra_args = []
 
     # deep copy here to prevent accidentally updating global settings.
-    settings = copy.deepcopy(_get_settings_by_document(document))
+    settings = copy.deepcopy(tool_server.get_settings_by_document(document))
 
     cwd = get_cwd(settings, document)
 
@@ -841,17 +759,17 @@ def _run_tool_on_document(
         # Let mypy use files defined by the configuration
         pass
 
-    log_to_output(" ".join(argv))
-    log_to_output(f"CWD Server: {cwd}")
+    tool_server.log_to_output(" ".join(argv))
+    tool_server.log_to_output(f"CWD Server: {cwd}")
     result = utils.run_path(
         argv=argv,
         cwd=cwd,
         env=_get_env_vars(settings),
     )
     if result.stderr:
-        log_to_output(result.stderr)
+        tool_server.log_to_output(result.stderr)
 
-    log_to_output(f"{document.uri} :\r\n{result.stdout}")
+    tool_server.log_to_output(f"{document.uri} :\r\n{result.stdout}")
     return result
 
 
@@ -873,14 +791,14 @@ def _run_dmypy_command(
 
     argv += _get_dmypy_args(settings, command)
     argv += extra_args
-    log_to_output(" ".join(argv))
-    log_to_output(f"CWD Server: {cwd}")
+    tool_server.log_to_output(" ".join(argv))
+    tool_server.log_to_output(f"CWD Server: {cwd}")
 
     result = utils.run_path(argv=argv, cwd=cwd, env=_get_env_vars(settings))
     if result.stderr:
-        log_to_output(result.stderr)
+        tool_server.log_to_output(result.stderr)
 
-    log_to_output(f"\r\n{result.stdout}\r\n")
+    tool_server.log_to_output(f"\r\n{result.stdout}\r\n")
     return result
 
 
@@ -890,37 +808,19 @@ def _run_dmypy_command(
 def log_to_output(
     message: str, msg_type: lsp.MessageType = lsp.MessageType.Log
 ) -> None:
-    LSP_SERVER.window_log_message(lsp.LogMessageParams(type=msg_type, message=message))
+    tool_server.log_to_output(message, msg_type)
 
 
 def log_error(message: str) -> None:
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Error, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onError", "onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Error, message=message)
-        )
+    tool_server.log_error(message)
 
 
 def log_warning(message: str) -> None:
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Warning, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Warning, message=message)
-        )
+    tool_server.log_warning(message)
 
 
 def log_always(message: str) -> None:
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Info, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Info, message=message)
-        )
+    tool_server.log_always(message)
 
 
 # *****************************************************

--- a/noxfile.py
+++ b/noxfile.py
@@ -127,7 +127,7 @@ def install_bundled_libs(session):
         "py",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.5.1",
+        "vscode-common-python-lsp==0.6.0",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "mypy-type-checker",
-    "version": "2026.5.0-dev",
+    "version": "2026.7.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mypy-type-checker",
-            "version": "2026.5.0-dev",
+            "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.5.1",
+                "@vscode/common-python-lsp": "^0.6.0",
                 "@vscode/python-extension": "^1.0.6",
                 "dotenv": "^17.4.1",
                 "fs-extra": "^11.3.1",
@@ -1094,6 +1094,7 @@
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -1286,9 +1287,9 @@
             "license": "ISC"
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
@@ -1835,6 +1836,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2180,6 +2182,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3152,6 +3155,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -6280,6 +6284,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7305,6 +7310,7 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7526,6 +7532,7 @@
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -7575,6 +7582,7 @@
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "0.5.1",
+        "@vscode/common-python-lsp": "^0.6.0",
         "@vscode/python-extension": "^1.0.6",
         "dotenv": "^17.4.1",
         "fs-extra": "^11.3.1",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,6 +27,7 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyMypyEnabled = legacyConfig.get<boolean>('linting.mypyEnabled', false);
+            const legacyMypyPath = legacyConfig.get<string>('linting.mypyPath', '');
             if (legacyMypyEnabled) {
                 traceWarn(`"python.linting.mypyEnabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -37,6 +38,11 @@ export function logLegacySettings(): void {
                     `"python.linting.mypyEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyMypyEnabled}`,
                 );
             }
+            if (legacyMypyPath.length > 0 && legacyMypyPath !== 'mypy') {
+                traceWarn(`"python.linting.mypyPath" is deprecated. Use "mypy-type-checker.path" instead.`);
+                traceWarn(`"python.linting.mypyPath" value for workspace ${workspace.uri.fsPath}:`);
+                traceWarn(`\n${JSON.stringify(legacyMypyPath, null, 4)}`);
+            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -46,6 +52,5 @@ export function logLegacySettings(): void {
     _logLegacySettings('mypy-type-checker', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.mypyArgs', newKey: 'args', isArray: true },
-        { legacyKey: 'linting.mypyPath', newKey: 'path' },
     ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,7 +27,6 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyMypyEnabled = legacyConfig.get<boolean>('linting.mypyEnabled', false);
-            const legacyMypyPath = legacyConfig.get<string>('linting.mypyPath', '');
             if (legacyMypyEnabled) {
                 traceWarn(`"python.linting.mypyEnabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -38,11 +37,6 @@ export function logLegacySettings(): void {
                     `"python.linting.mypyEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyMypyEnabled}`,
                 );
             }
-            if (legacyMypyPath.length > 0 && legacyMypyPath !== 'mypy') {
-                traceWarn(`"python.linting.mypyPath" is deprecated. Use "mypy-type-checker.path" instead.`);
-                traceWarn(`"python.linting.mypyPath" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyMypyPath, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -52,5 +46,6 @@ export function logLegacySettings(): void {
     _logLegacySettings('mypy-type-checker', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.mypyArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.mypyPath', newKey: 'path', defaultValue: 'mypy' },
     ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -4,7 +4,13 @@
 // Extension-specific settings: ISettings type extension and legacy settings logging.
 // All shared settings resolution is handled by @vscode/common-python-lsp directly.
 
-import { IBaseSettings, getConfiguration, getWorkspaceFolders, traceWarn } from '@vscode/common-python-lsp';
+import {
+    IBaseSettings,
+    getConfiguration,
+    getWorkspaceFolders,
+    logLegacySettings as _logLegacySettings,
+    traceWarn,
+} from '@vscode/common-python-lsp';
 
 export interface ISettings extends IBaseSettings {
     ignorePatterns: string[];
@@ -15,10 +21,11 @@ export interface ISettings extends IBaseSettings {
 }
 
 export function logLegacySettings(): void {
+    // Handle mypyEnabled separately — it has custom messaging not covered
+    // by the shared helper's simple "use X instead" pattern.
     getWorkspaceFolders().forEach((workspace) => {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
-
             const legacyMypyEnabled = legacyConfig.get<boolean>('linting.mypyEnabled', false);
             if (legacyMypyEnabled) {
                 traceWarn(`"python.linting.mypyEnabled" is deprecated. You can remove that setting.`);
@@ -30,28 +37,15 @@ export function logLegacySettings(): void {
                     `"python.linting.mypyEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyMypyEnabled}`,
                 );
             }
-
-            const legacyCwd = legacyConfig.get<string>('linting.cwd');
-            if (legacyCwd) {
-                traceWarn(`"python.linting.cwd" is deprecated. Use "mypy-type-checker.cwd" instead.`);
-                traceWarn(`"python.linting.cwd" value for workspace ${workspace.uri.fsPath}: ${legacyCwd}`);
-            }
-
-            const legacyArgs = legacyConfig.get<string[]>('linting.mypyArgs', []);
-            if (legacyArgs.length > 0) {
-                traceWarn(`"python.linting.mypyArgs" is deprecated. Use "mypy-type-checker.args" instead.`);
-                traceWarn(`"python.linting.mypyArgs" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyArgs, null, 4)}`);
-            }
-
-            const legacyPath = legacyConfig.get<string>('linting.mypyPath', '');
-            if (legacyPath.length > 0 && legacyPath !== 'mypy') {
-                traceWarn(`"python.linting.mypyPath" is deprecated. Use "mypy-type-checker.path" instead.`);
-                traceWarn(`"python.linting.mypyPath" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
     });
+
+    // Standard legacy key → new key mappings handled by the shared helper.
+    _logLegacySettings('mypy-type-checker', [
+        { legacyKey: 'linting.cwd', newKey: 'cwd' },
+        { legacyKey: 'linting.mypyArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.mypyPath', newKey: 'path' },
+    ]);
 }


### PR DESCRIPTION
## Summary
Reduce code duplication between this extension and the shared package `@vscode/common-python-lsp` (`vscode-common-python-lsp`).

### Changes
- **`src/common/settings.ts`**: Use shared `logLegacySettings()` instead of inline legacy-setting migration warnings
- **`bundled/tool/lsp_server.py`**: Migrate to `ToolServer`/`ToolServerConfig` from the shared package — replaces hand-rolled settings management, CWD resolution, tool execution, logging, and lifecycle handlers with shared implementations

### Impact
- Significant reduction in duplicated code across all extension repos
- Tool-specific logic (formatting, code actions, daemon management, etc.) remains local
- No behavioral changes — all existing functionality preserved
- No test modifications