### PR TITLE
handle missing daemon status file setting

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -631,8 +631,9 @@ def _get_dmypy_args(settings: Dict[str, Any], command: str) -> List[str]:
         raise ValueError(f"Invalid dmypy command: {command}")
 
     if key not in DMYPY_ARGS:
-        if settings["daemonStatusFile"]:
-            STATUS_FILE_NAME = settings["daemonStatusFile"]
+        daemon_status_file = settings.get("daemonStatusFile", "")
+        if daemon_status_file:
+            STATUS_FILE_NAME = daemon_status_file
         else:
             STATUS_FILE_NAME = os.fspath(
                 DMYPY_STATUS_FILE_ROOT / f"status-{str(uuid.uuid4())}.json"

--- a/src/test/python_tests/test_dmypy_status_file.py
+++ b/src/test/python_tests/test_dmypy_status_file.py
@@ -56,6 +56,23 @@ def test_dmypy_args_generates_status_file_when_not_set():
         _clear_dmypy_cache()
 
 
+def test_dmypy_args_generates_status_file_when_setting_is_missing():
+    """Older settings payloads may not include daemonStatusFile."""
+    _clear_dmypy_cache()
+    old_root = lsp_server.DMYPY_STATUS_FILE_ROOT
+    lsp_server.DMYPY_STATUS_FILE_ROOT = pathlib.Path(os.environ.get("TEMP", "/tmp"))
+    try:
+        settings = {"workspaceFS": "/workspace/missing_setting"}
+        result = lsp_server._get_dmypy_args(settings, "run")
+        assert "--status-file" in result
+        idx = result.index("--status-file")
+        assert result[idx + 1] != ""
+        assert "status-" in result[idx + 1]
+    finally:
+        lsp_server.DMYPY_STATUS_FILE_ROOT = old_root
+        _clear_dmypy_cache()
+
+
 def test_dmypy_args_run_includes_separator():
     """The 'run' command includes a '--' separator after the command."""
     _clear_dmypy_cache()


### PR DESCRIPTION
﻿Fixes #549.

The dmypy argument builder already treats an empty `daemonStatusFile` as "generate one for this workspace", but it accessed the setting with `settings["daemonStatusFile"]`. Older or partial settings payloads can omit that key entirely, which makes `preferDaemon` fail with a `KeyError` before dmypy is launched.

This keeps the existing behavior for configured values, but falls back to an empty string when the setting is missing so the normal generated status-file path is used.

Checked locally:
- `python -m pytest -q src/test/python_tests/test_dmypy_status_file.py`
- `python -m pytest -q src/test/python_tests/test_global_defaults.py`
- direct `_get_dmypy_args({"workspaceFS": ...}, "run")` call with `DMYPY_STATUS_FILE_ROOT` initialized
- `python -m py_compile bundled/tool/lsp_server.py src/test/python_tests/test_dmypy_status_file.py`
- `git diff --check`
