### PR TITLE
Add mypy problem matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,27 @@
         "vsce-package-pre": "vsce package -o mypy.vsix --pre-release"
     },
     "contributes": {
+        "problemMatcher": [
+            {
+                "owner": "mypy",
+                "source": "mypy",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceFolder}"
+                ],
+                "pattern": {
+                    "regexp": "^([^:]+):(\\d+):(?:(\\d+):(?:(\\d+):(\\d+):)?)? (\\w+): (.+?)(?:\\s*\\[([\\w-]+)\\])?\\s*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "endLine": 4,
+                    "endColumn": 5,
+                    "severity": 6,
+                    "message": 7,
+                    "code": 8
+                }
+            }
+        ],
         "configuration": {
             "properties": {
                 "mypy-type-checker.args": {

--- a/package.json
+++ b/package.json
@@ -70,10 +70,7 @@
             {
                 "owner": "mypy",
                 "source": "mypy",
-                "fileLocation": [
-                    "relative",
-                    "${workspaceFolder}"
-                ],
+                "fileLocation": "autoDetect",
                 "pattern": {
                     "regexp": "^([^:]+):(\\d+):(?:(\\d+):(?:(\\d+):(\\d+):)?)? (\\w+): (.+?)(?:\\s*\\[([\\w-]+)\\])?\\s*$",
                     "file": 1,


### PR DESCRIPTION
Supports combinations of `--show-column-numbers`, `--hide-error-codes` and `--show-error-end`.

Sample string for test:

```plain
main.py:1: error: Unsupported operand types for - ("int" and "str")  [operator]
main.py:1: note: See 'https://mypy.rtfd.io/en/stable/_refs.html#code-operator' for more info
main.py:1:2:3:4: error: Unsupported operand types for - ("int" and "str")  [operator]
main.py:1:2:3:4: note: See 'https://mypy.rtfd.io/en/stable/_refs.html#code-operator' for more info
main.py:1:2: error: Unsupported operand types for - ("int" and "str")  [operator]
main.py:1:2: note: See 'https://mypy.rtfd.io/en/stable/_refs.html#code-operator' for more info
```

Expect:
- line=1 (×2 lines)
- line=1,column=2,endLine=3,endColumn=4 (×2 lines)
- line=1,column=2 (×2 lines)

([regex101 test](https://regex101.com/?regex=%5E%28%5B%5E%3A%5D%2B%29%3A%28%5Cd%2B%29%3A%28%3F%3A%28%5Cd%2B%29%3A%28%3F%3A%28%5Cd%2B%29%3A%28%5Cd%2B%29%3A%29%3F%29%3F+%28%5Cw%2B%29%3A+%28.%2B%3F%29%28%3F%3A%5Cs*%5C%5B%28%5B%5Cw-%5D%2B%29%5C%5D%29%3F%5Cs*%24&testString=main.py%3A1%3A+error%3A+Unsupported+operand+types+for+-+%28%22int%22+and+%22str%22%29++%5Boperator%5D%0Amain.py%3A1%3A+note%3A+See+%27https%3A%2F%2Fmypy.rtfd.io%2Fen%2Fstable%2F_refs.html%23code-operator%27+for+more+info%0Amain.py%3A1%3A2%3A3%3A4%3A+error%3A+Unsupported+operand+types+for+-+%28%22int%22+and+%22str%22%29++%5Boperator%5D%0Amain.py%3A1%3A2%3A3%3A4%3A+note%3A+See+%27https%3A%2F%2Fmypy.rtfd.io%2Fen%2Fstable%2F_refs.html%23code-operator%27+for+more+info%0Amain.py%3A1%3A2%3A+error%3A+Unsupported+operand+types+for+-+%28%22int%22+and+%22str%22%29++%5Boperator%5D%0Amain.py%3A1%3A2%3A+note%3A+See+%27https%3A%2F%2Fmypy.rtfd.io%2Fen%2Fstable%2F_refs.html%23code-operator%27+for+more+info&flags=gm&flavor=pcre2&delimiter=%2F))

Note: This is a remake of #582 with commit message fixed