### PR TITLE
Use Python 3.10 in Azure validation pipeline

### DIFF
--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -17,6 +17,8 @@ variables:
     value: VSCode-mypy
   - name: VsixName
     value: mypy.vsix
+  - name: PythonVersion
+    value: '3.10'
   - name: AZURE_ARTIFACTS_FEED
     value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
 
@@ -26,6 +28,10 @@ parameters:
     default:
       - script: git submodule update --init --recursive
         displayName: Checkout submodules
+      - task: UsePythonVersion@0
+        displayName: Use Python $(PythonVersion)
+        inputs:
+          versionSpec: $(PythonVersion)
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -17,8 +17,6 @@ variables:
     value: VSCode-mypy
   - name: VsixName
     value: mypy.vsix
-  - name: PythonVersion
-    value: '3.10'
   - name: AZURE_ARTIFACTS_FEED
     value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
 
@@ -28,10 +26,6 @@ parameters:
     default:
       - script: git submodule update --init --recursive
         displayName: Checkout submodules
-      - task: UsePythonVersion@0
-        displayName: Use Python $(PythonVersion)
-        inputs:
-          versionSpec: $(PythonVersion)
       - script: npm ci
         displayName: Install NPM dependencies
 
@@ -72,3 +66,4 @@ extends:
               isPreRelease: true
               standardizedVersioning: true
               customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              pythonVersion: '3.10'


### PR DESCRIPTION
## Summary

- explicitly select Python 3.10 in the Azure validation pipeline
- avoid the external job template's Python 3.9 default before installing Nox and bundled dependencies
- replace the previous PR to retrigger Azure validation

## Validation

- parsed the updated pipeline as YAML and verified the Python task ordering
- verified Prettier formatting