### PR TITLE
Remove dependencies provided by shared package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'debt'
@@ -22,7 +23,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
@@ -57,7 +57,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
 
   # The shared package submodule is updated daily in a standalone PR.
   - package-ecosystem: 'gitsubmodule'
@@ -81,4 +80,3 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
-      - dependency-name: 'vscode-languageclient'
 
   - package-ecosystem: 'pip'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,26 @@ updates:
     directories:
       - '/'
       - '/src/test/python_tests'
+    # Multi-ecosystem groups only support positive patterns. Keep mypy
+    # unmatched so its updates remain standalone.
     patterns:
-      - '*'
-    exclude-patterns:
-      - 'mypy'
+      - 'attrs'
+      - 'cattrs'
+      - 'colorama'
+      - 'exceptiongroup'
+      - 'iniconfig'
+      - 'lsprotocol'
+      - 'mypy-extensions'
+      - 'packaging'
+      - 'pluggy'
+      - 'pygls'
+      - 'pygments'
+      - 'pyhamcrest'
+      - 'pytest'
+      - 'python-jsonrpc-server'
+      - 'tomli'
+      - 'typing-extensions'
+      - 'ujson'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
-    exclude-patterns:
-      - 'mypy'
     labels:
       - 'dependencies'
       - 'debt'
@@ -38,6 +36,8 @@ updates:
       - '/src/test/python_tests'
     patterns:
       - '*'
+    exclude-patterns:
+      - 'mypy'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,7 +69,6 @@ def _get_package_data(package):
 
 def _update_npm_packages(session: nox.Session) -> None:
     pinned = {
-        "vscode-languageclient",
         "@types/vscode",
         "@types/node",
         "@vscode/common-python-lsp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-                "@vscode/python-extension": "^1.0.6",
-                "dotenv": "^17.4.1",
-                "fs-extra": "^11.3.1",
-                "vscode-languageclient": "^9.0.1"
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.11",
@@ -26,11 +22,11 @@
                 "@types/vscode": "^1.74.0",
                 "@typescript-eslint/eslint-plugin": "^8.57.0",
                 "@typescript-eslint/parser": "^8.57.0",
-                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/test-electron": "^2.3.8",
                 "@vscode/vsce": "^3.9.2",
                 "chai": "^6.2.2",
                 "eslint": "^10.0.3",
+                "fs-extra": "^11.3.1",
                 "glob": "^13.0.6",
                 "mocha": "^11.7.2",
                 "prettier": "^3.2.4",
@@ -8294,57 +8290,6 @@
             "funding": {
                 "url": "https://bevry.me/fund"
             }
-        },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageclient": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
-            "license": "MIT",
-            "dependencies": {
-                "minimatch": "^5.1.0",
-                "semver": "^7.3.7",
-                "vscode-languageserver-protocol": "3.17.5"
-            },
-            "engines": {
-                "vscode": "^1.82.0"
-            }
-        },
-        "node_modules/vscode-languageclient/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.2.0",
-                "vscode-languageserver-types": "3.17.5"
-            }
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-            "license": "MIT"
         },
         "node_modules/watchpack": {
             "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -232,11 +232,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-        "@vscode/python-extension": "^1.0.6",
-        "dotenv": "^17.4.1",
-        "fs-extra": "^11.3.1",
-        "vscode-languageclient": "^9.0.1"
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
     },
     "devDependencies": {
         "@types/chai": "^4.3.11",
@@ -248,11 +244,11 @@
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
-        "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/test-electron": "^2.3.8",
         "@vscode/vsce": "^3.9.2",
         "chai": "^6.2.2",
         "eslint": "^10.0.3",
+        "fs-extra": "^11.3.1",
         "glob": "^13.0.6",
         "mocha": "^11.7.2",
         "prettier": "^3.2.4",


### PR DESCRIPTION
## Summary  - remove extension-level npm dependencies already provided by `@vscode/common-python-lsp`  - keep dependencies still imported by extension-owned source or tests - remove stale dependency-update exclusions where the shared package now owns the dependency   ## Dependabot configuration  - use supported positive `patterns` to group all currently locked non-tool Python dependencies - leave the primary tool unmatched so its updates remain standalone 
- set the pull request limit on the multi-ecosystem group, as required by Dependabot's schema